### PR TITLE
Add eslint rule @typescript-eslint/no-explicit-any, @typescript-eslint/strict-boolean-expressions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,17 +12,17 @@ import tseslint from 'typescript-eslint';
 export default [
   {
     ignores: [
-      '.yarn/**',
-      'coverage/**',
-      '**/dist/**',
-      '**/cache/**',
-      '.pnp.*',
       '**/*.d.ts',
       '**/*.tgz',
-      'node_modules/**',
-      'vitest.*',
+      '**/dist/**',
+      '**/cache/**',
+      '.yarn/**',
+      '.pnp.*',
+      'coverage',
       'docs',
+      'node_modules',
       'eslint.*',
+      'vitest.*',
     ],
   },
   {


### PR DESCRIPTION
As we mentioned before, i changed @typescript-eslint/no-explicit-any rule as "warning".
With this, I add @typescript-eslint/strict-boolean-expressions rule too.
It prevents implicit actions that may occur due to the [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) action of javascript.