### PR TITLE
chore: move openai to devDependencies

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -14504,20 +14504,18 @@ Require stack:
     }
     return false;
   };
-  if (!process.features.require_module) {
-    const originalExtensionJSFunction = require$$0.Module._extensions[`.js`];
-    require$$0.Module._extensions[`.js`] = function(module, filename) {
-      if (filename.endsWith(`.js`)) {
-        const pkg = readPackageScope(filename);
-        if (pkg && pkg.data?.type === `module`) {
-          const err = ERR_REQUIRE_ESM(filename, module.parent?.filename);
-          Error.captureStackTrace(err);
-          throw err;
-        }
+  const originalExtensionJSFunction = require$$0.Module._extensions[`.js`];
+  require$$0.Module._extensions[`.js`] = function(module, filename) {
+    if (filename.endsWith(`.js`)) {
+      const pkg = readPackageScope(filename);
+      if (pkg && pkg.data?.type === `module`) {
+        const err = ERR_REQUIRE_ESM(filename, module.parent?.filename);
+        Error.captureStackTrace(err);
+        throw err;
       }
-      originalExtensionJSFunction.call(this, module, filename);
-    };
-  }
+    }
+    originalExtensionJSFunction.call(this, module, filename);
+  };
   const originalDlopen = process.dlopen;
   process.dlopen = function(...args) {
     const [module, filename, ...rest] = args;

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "jsdom": "^25.0.1",
     "listr2": "^8.2.5",
     "nanoid": "^5.1.5",
+    "openai": "^4.93.0",
     "ora": "^8.2.0",
     "prettier": "^3.4.2",
     "prettier-plugin-sort-re-exports": "^0.1.0",
@@ -79,8 +80,5 @@
     "react": "*",
     "react-dom": "*"
   },
-  "packageManager": "yarn@4.5.3",
-  "dependencies": {
-    "openai": "^4.93.0"
-  }
+  "packageManager": "yarn@4.5.3"
 }


### PR DESCRIPTION
## Checklist

Move OpenAI package from dependencies to devDependencies since it's only used in development environment.

- [x] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
