### PR TITLE
ci(codecov): setup

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Run tests and generate coverage
         run: yarn run test:coverage
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Verify test coverage
         run: |
           changed_files="${{ needs.check-changes.outputs.changed_files }}"

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -1,6 +1,6 @@
 ![react-simplikit](src/public/images/og.png)
 
-# react-simplikit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE)
+# react-simplikit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE) [![codecov](https://codecov.io/gh/toss/react-simplikit/branch/main/graph/badge.svg?token=5PopssACmx)](https://codecov.io/gh/toss/react-simplikit)
 
 [English](./README.md) | 한국어
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![react-simplikit](./src/public/images/og.png)
 
-# react-simplikit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE)
+# react-simplikit &middot; [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/toss/slash/blob/main/LICENSE) [![codecov](https://codecov.io/gh/toss/react-simplikit/branch/main/graph/badge.svg?token=5PopssACmx)](https://codecov.io/gh/toss/react-simplikit)
 
 English | [Korean](./README-ko_kr.md)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    patch: off
+    project:
+      default:
+        target: 100%
+        threshold: 10%
+
+comment:
+  layout: 'header, reach, diff, flags, components'
+
+ignore:
+  - '**/*.test-d.*'


### PR DESCRIPTION
Same with https://github.com/toss/es-toolkit/pull/34

1. Please add the Codecov GitHub bot: https://github.com/apps/codecov

    From now on, it will check changes via comments, and if the target test coverage (set at 90%, goal: 100%, threshold: 10%) is not met, it will block with an X in the GitHub status check. This will motivate contributors to write test codes and allow maintainers to quickly identify test coverage impacts from changes.

    <img width="989" alt="image" src="https://github.com/toss/es-hangul/assets/61593290/c455f096-fbe1-4b64-8bf9-15be0f524142">

2. The organization and this repository need to be registered with Codecov.
    
    Once this PR is merged, it will be set up and start tracking coverage.

    <img width="1718" alt="image" src="https://github.com/toss/es-hangul/assets/61593290/e3f2ad6a-7546-43d6-a200-57a9bb84276e">

3. Before merging, a CODECOV_TOKEN for upload needs to be added.
A token is required for uploads.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
