### PR TITLE
chore(eslint): add 'tsup.*' in ignores

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ export default [
       'docs',
       'node_modules',
       'eslint.*',
+      'tsup.*',
       'vitest.*',
       '.vitepress',
     ],


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

* With addding `tsup.*` in ignores, we can fix this problem. 

## before

<img width="1153" alt="image" src="https://github.com/user-attachments/assets/722ab412-917a-4a58-bbb0-46b082bce56e" />

## after

<img width="981" alt="image" src="https://github.com/user-attachments/assets/9d1e3ac4-db82-4545-a472-4d405ec42cd2" />


## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
