### PR TITLE
chore(.scripts/commands/generateDocs): disable eslint 'unused-imports/no-unused-vars' warning

### DIFF
--- a/.scripts/commands/generateDocs/index.ts
+++ b/.scripts/commands/generateDocs/index.ts
@@ -43,7 +43,7 @@ export async function generateDocs(names: string[]) {
                       await fs.access(`${dirname}/${name}.md`);
                       await fs.access(`${dirname}/ko/${name}.md`);
                       isFileExists = true;
-                      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                      // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
                     } catch (_) {
                       isFileExists = false;
                     }


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
