### PR TITLE
chore: apply global Prettier formatting based on project config

### DIFF
--- a/src/components/ImpressionArea/ImpressionArea.md
+++ b/src/components/ImpressionArea/ImpressionArea.md
@@ -3,9 +3,10 @@
 `ImpressionArea` is a component that measures the time a specific DOM element is visible on the screen and executes callbacks when the element enters or exits the viewport. This component uses the `useImpressionRef` hook to track the element's visibility.
 
 ## Interface
+
 ```ts
 function ImpressionArea(
-  as: ElementType = "div",
+  as: ElementType = 'div',
   rootMargin: string,
   areaThreshold: number,
   timeThreshold: number,
@@ -13,9 +14,8 @@ function ImpressionArea(
   onImpressionEnd: () => void,
   ref: Ref<HTMLElement>,
   children: React.ReactNode,
-  className: string,
+  className: string
 ): JSX.Element;
-
 ```
 
 ### Parameters
@@ -82,7 +82,6 @@ function ImpressionArea(
   description="React component that tracks the visibility of its child elements."
 />
 
-
 ## Example
 
 ```tsx
@@ -99,4 +98,3 @@ function App() {
   );
 }
 ```
-  

--- a/src/components/Separated/Separated.md
+++ b/src/components/Separated/Separated.md
@@ -3,9 +3,9 @@
 `Separated` is a component that inserts a specified component between each child element. It is useful for adding separators, spacing, or other repeating elements in lists.
 
 ## Interface
+
 ```ts
 function Separated(children: React.ReactNode, by: React.ReactNode): JSX.Element;
-
 ```
 
 ### Parameters
@@ -32,7 +32,6 @@ function Separated(children: React.ReactNode, by: React.ReactNode): JSX.Element;
   description="React component that separates children with a specified separator."
 />
 
-
 ## Example
 
 ```tsx
@@ -52,4 +51,3 @@ function App() {
   // <div>world</div>
 }
 ```
-  

--- a/src/components/Separated/ko/Separated.md
+++ b/src/components/Separated/ko/Separated.md
@@ -3,9 +3,9 @@
 `Separated`는 각 자식 요소 사이에 지정된 컴포넌트를 삽입하는 컴포넌트예요. 리스트에서 구분자, 간격 또는 다른 반복 요소를 추가하는 데 유용해요.
 
 ## 인터페이스
+
 ```ts
 function Separated(children: React.ReactNode, by: React.ReactNode): JSX.Element;
-
 ```
 
 ### 파라미터
@@ -32,7 +32,6 @@ function Separated(children: React.ReactNode, by: React.ReactNode): JSX.Element;
   description="지정한 구분자로 자식을 구분하는 리액트 컴포넌트예요."
 />
 
-
 ## 예시
 
 ```tsx
@@ -52,4 +51,3 @@ function App() {
   // <div>world</div>
 }
 ```
-  

--- a/src/components/SwitchCase/SwitchCase.md
+++ b/src/components/SwitchCase/SwitchCase.md
@@ -3,13 +3,13 @@
 `SwitchCase` is a component that allows you to declaratively render components based on a given value, similar to a `switch-case` statement. It is useful when you need to conditionally render different components depending on a specific state.
 
 ## Interface
+
 ```ts
 function SwitchCase(
   value: string | number,
   caseBy: Record<string | number, () => JSX.Element>,
-  defaultComponent: () => JSX.Element,
+  defaultComponent: () => JSX.Element
 ): JSX.Element;
-
 ```
 
 ### Parameters
@@ -43,7 +43,6 @@ function SwitchCase(
   description="React component that conditionally renders based on cases."
 />
 
-
 ## Example
 
 ```tsx
@@ -63,4 +62,3 @@ function App() {
   );
 }
 ```
-  

--- a/src/components/SwitchCase/ko/SwitchCase.md
+++ b/src/components/SwitchCase/ko/SwitchCase.md
@@ -3,13 +3,13 @@
 `SwitchCase`는 주어진 값에 기반하여 선언적으로 컴포넌트를 렌더링할 수 있는 컴포넌트예요, 마치 `switch-case` 문장과 비슷해요. 이는 특정 상태에 따라 다른 컴포넌트를 조건부로 렌더링해야 할 때 유용해요.
 
 ## 인터페이스
+
 ```ts
 function SwitchCase(
   value: string | number,
   caseBy: Record<string | number, () => JSX.Element>,
-  defaultComponent: () => JSX.Element,
+  defaultComponent: () => JSX.Element
 ): JSX.Element;
-
 ```
 
 ### 파라미터
@@ -43,7 +43,6 @@ function SwitchCase(
   description="케이스에 따라 조건부로 렌더링하는 리액트 컴포넌트예요."
 />
 
-
 ## 예시
 
 ```tsx
@@ -53,9 +52,9 @@ function App() {
       value={status}
       // 상태 값에 따라 TypeA, TypeB 또는 TypeC를 렌더링해요.
       caseBy={{
-        a: () => <TypeA />, 
-        b: () => <TypeB />, 
-        c: () => <TypeC />, 
+        a: () => <TypeA />,
+        b: () => <TypeB />,
+        c: () => <TypeC />,
       }}
       // 상태 값이 어떤 케이스와도 일치하지 않으면 Default를 렌더링해요.
       defaultComponent={() => <Default />}
@@ -63,4 +62,3 @@ function App() {
   );
 }
 ```
-  

--- a/src/docs/en/intro.md
+++ b/src/docs/en/intro.md
@@ -14,7 +14,8 @@ We provide a development experience as similar as possible to using React's decl
 function Page() {
   const [isOpen, setOpen] = useState(false); // [!code --]
   // [!code --]
-  const toggle = useCallback(() => { // [!code --]
+  const toggle = useCallback(() => {
+    // [!code --]
     setOpen(isOpen => !isOpen); // [!code --]
   }, []); // [!code --]
   const [isOpen, toggle] = useToggle(false); // [!code ++]
@@ -39,19 +40,15 @@ const texts = ['hello', 'react', 'world'];
 function Page() {
   return (
     <>
-      {texts.map((text, idx) =>
+      {texts.map((text, idx) => (
         <Fragment key={text}>
           <div>{text}</div>
-          {idx < texts.length - 1
-            ? <Border type="padding24" />
-            : null
-          }
+          {idx < texts.length - 1 ? <Border type="padding24" /> : null}
         </Fragment>
-      )}
+      ))}
     </>
   );
 }
-
 ```
 
   </template>
@@ -70,7 +67,6 @@ function Page() {
     </Separated>
   );
 }
-
 ```
 
   </template>

--- a/src/docs/ko/intro.md
+++ b/src/docs/ko/intro.md
@@ -14,7 +14,8 @@ React의 선언적인 API를 사용할 때와 최대한 유사한 개발 경험�
 function Page() {
   const [isOpen, setOpen] = useState(false); // [!code --]
   // [!code --]
-  const toggle = useCallback(() => { // [!code --]
+  const toggle = useCallback(() => {
+    // [!code --]
     setOpen(isOpen => !isOpen); // [!code --]
   }, []); // [!code --]
   const [isOpen, toggle] = useToggle(false); // [!code ++]
@@ -39,19 +40,15 @@ const texts = ['hello', 'react', 'world'];
 function Page() {
   return (
     <>
-      {texts.map((text, idx) =>
+      {texts.map((text, idx) => (
         <Fragment key={text}>
           <div>{text}</div>
-          {idx < texts.length - 1
-            ? <Border type="padding24" />
-            : null
-          }
+          {idx < texts.length - 1 ? <Border type="padding24" /> : null}
         </Fragment>
-      )}
+      ))}
     </>
   );
 }
-
 ```
 
   </template>
@@ -70,7 +67,6 @@ function Page() {
     </Separated>
   );
 }
-
 ```
 
   </template>

--- a/src/hooks/useAsyncEffect/ko/useAsyncEffect.md
+++ b/src/hooks/useAsyncEffect/ko/useAsyncEffect.md
@@ -3,12 +3,9 @@
 `useAsyncEffect`는 리액트 컴포넌트에서 비동기 사이드이펙트를 처리하기 위한 커스텀 훅이에요. `useEffect`와 동일한 정리(clean-up) 패턴을 따르면서 비동기 작업이 안전하게 처리되도록 해요.
 
 ## 인터페이스
-```ts
-function useAsyncEffect(
-  effect: () => Promise<void | (() => void)>,
-  deps: DependencyList,
-): void;
 
+```ts
+function useAsyncEffect(effect: () => Promise<void | (() => void)>, deps: DependencyList): void;
 ```
 
 ### 파라미터
@@ -41,4 +38,3 @@ useAsyncEffect(async () => {
   };
 }, [dependencies]);
 ```
-  

--- a/src/hooks/useAsyncEffect/useAsyncEffect.md
+++ b/src/hooks/useAsyncEffect/useAsyncEffect.md
@@ -3,12 +3,9 @@
 `useAsyncEffect` is a custom hook for handling asynchronous side effects in React components. It follows the same cleanup pattern as `useEffect` while ensuring async operations are handled safely.
 
 ## Interface
-```ts
-function useAsyncEffect(
-  effect: () => Promise<void | (() => void)>,
-  deps: DependencyList,
-): void;
 
+```ts
+function useAsyncEffect(effect: () => Promise<void | (() => void)>, deps: DependencyList): void;
 ```
 
 ### Parameters
@@ -41,4 +38,3 @@ useAsyncEffect(async () => {
   };
 }, [dependencies]);
 ```
-  

--- a/src/hooks/useBooleanState/ko/useBooleanState.md
+++ b/src/hooks/useBooleanState/ko/useBooleanState.md
@@ -3,16 +3,11 @@
 `useBooleanState`는 불리언 상태 관리를 단순화하는 리액트 훅이에요. 상태를 `true`로 설정하고, `false`로 설정하고, 그 값을 토글할 수 있는 함수를 제공해요.
 
 ## Interface
+
 ```ts
 function useBooleanState(
-  defaultValue: boolean = false,
-): [
-  state: boolean,
-  setTrue: () => void,
-  setFalse: () => void,
-  toggle: () => void,
-];
-
+  defaultValue: boolean = false
+): [state: boolean, setTrue: () => void, setFalse: () => void, toggle: () => void];
 ```
 
 ### 파라미터
@@ -53,10 +48,8 @@ function useBooleanState(
   ]"
 />
 
-
 ## 예시
 
 ```tsx
 const [open, openBottomSheet, closeBottomSheet, toggleBottomSheet] = useBooleanState(false);
 ```
-  

--- a/src/hooks/useBooleanState/useBooleanState.md
+++ b/src/hooks/useBooleanState/useBooleanState.md
@@ -3,16 +3,11 @@
 `useBooleanState` is a React hook that simplifies managing a boolean state. It provides functions to set the state to `true`, set it to `false`, and toggle its value.
 
 ## Interface
+
 ```ts
 function useBooleanState(
-  defaultValue: boolean = false,
-): [
-  state: boolean,
-  setTrue: () => void,
-  setFalse: () => void,
-  toggle: () => void,
-];
-
+  defaultValue: boolean = false
+): [state: boolean, setTrue: () => void, setFalse: () => void, toggle: () => void];
 ```
 
 ### Parameters
@@ -53,10 +48,8 @@ function useBooleanState(
   ]"
 />
 
-
 ## Example
 
 ```tsx
 const [open, openBottomSheet, closeBottomSheet, toggleBottomSheet] = useBooleanState(false);
 ```
-  

--- a/src/hooks/useCallbackOncePerRender/ko/useCallbackOncePerRender.md
+++ b/src/hooks/useCallbackOncePerRender/ko/useCallbackOncePerRender.md
@@ -3,12 +3,9 @@
 리액트 훅으로, 콜백 함수가 한 번만 실행되도록 보장해요. 몇 번 호출되든 간에 단 한 번만 실행돼요. 이는 컴포넌트가 다시 렌더링되더라도 반복되지 말아야 하는 일회성 작업에 유용해요.
 
 ## 인터페이스
-```ts
-function useCallbackOncePerRender(
-  callback: () => void,
-  deps: DependencyList,
-): (...args: any[]) => void;
 
+```ts
+function useCallbackOncePerRender(callback: () => void, deps: DependencyList): (...args: any[]) => void;
 ```
 
 ### 파라미터
@@ -35,7 +32,6 @@ function useCallbackOncePerRender(
   description="의존성이 변경될 때까지 한 번만 실행될 메모이제이션된 함수예요."
 />
 
-
 ## 예시
 
 ```tsx
@@ -49,5 +45,3 @@ function Component() {
   return <button onClick={handleOneTimeEvent}>누르세요</button>;
 }
 ```
-
-

--- a/src/hooks/useCallbackOncePerRender/useCallbackOncePerRender.md
+++ b/src/hooks/useCallbackOncePerRender/useCallbackOncePerRender.md
@@ -3,12 +3,9 @@
 A React hook that ensures a callback function is executed only once, regardless of how many times it's called. This is useful for one-time operations that should not be repeated, even if the component re-renders.
 
 ## Interface
-```ts
-function useCallbackOncePerRender(
-  callback: () => void,
-  deps: DependencyList,
-): (...args: any[]) => void;
 
+```ts
+function useCallbackOncePerRender(callback: () => void, deps: DependencyList): (...args: any[]) => void;
 ```
 
 ### Parameters
@@ -35,7 +32,6 @@ function useCallbackOncePerRender(
   description="memoized function that will only execute once until dependencies change."
 />
 
-
 ## Example
 
 ```tsx
@@ -49,4 +45,3 @@ function Component() {
   return <button onClick={handleOneTimeEvent}>Click me</button>;
 }
 ```
-  

--- a/src/hooks/useDebounce/ko/useDebounce.md
+++ b/src/hooks/useDebounce/ko/useDebounce.md
@@ -3,13 +3,13 @@
 `useDebounce`는 제공된 콜백 함수의 디바운스 버전을 반환하는 리액트 훅이에요. 함수 실행을 지연시키고 여러 호출을 하나로 묶어줌으로써 이벤트 처리를 최적화하는 데 도움을 줘요.
 
 ## 인터페이스
+
 ```ts
 function useDebounce<F extends (...args: unknown[]) => unknown>(
   callback: F,
   wait: number,
-  options: DebounceOptions,
+  options: DebounceOptions
 ): F & { cancel: () => void };
-
 ```
 
 ### 파라미터
@@ -58,7 +58,6 @@ function useDebounce<F extends (...args: unknown[]) => unknown>(
   description="콜백 호출을 지연시키는 디바운스된 함수예요. 또한, 대기 중인 디바운스 실행을 취소할 수 있는 <code>cancel</code> 메서드를 포함해요."
 />
 
-
 ## 예시
 
 ```tsx
@@ -82,4 +81,3 @@ function SearchInput() {
   );
 }
 ```
-  

--- a/src/hooks/useDebounce/useDebounce.md
+++ b/src/hooks/useDebounce/useDebounce.md
@@ -3,13 +3,13 @@
 `useDebounce` is a React hook that returns a debounced version of the provided callback function. It helps optimize event handling by delaying function execution and grouping multiple calls into one.
 
 ## Interface
+
 ```ts
 function useDebounce<F extends (...args: unknown[]) => unknown>(
   callback: F,
   wait: number,
-  options: DebounceOptions,
+  options: DebounceOptions
 ): F & { cancel: () => void };
-
 ```
 
 ### Parameters
@@ -58,7 +58,6 @@ function useDebounce<F extends (...args: unknown[]) => unknown>(
   description="debounced function that delays invoking the callback. It also includes a <code>cancel</code> method to cancel any pending debounced execution."
 />
 
-
 ## Example
 
 ```tsx
@@ -82,4 +81,3 @@ function SearchInput() {
   );
 }
 ```
-  

--- a/src/hooks/useDebouncedCallback/ko/useDebouncedCallback.md
+++ b/src/hooks/useDebouncedCallback/ko/useDebouncedCallback.md
@@ -3,9 +3,9 @@
 `useDebouncedCallback`는 제공된 콜백 함수를 디바운스된 버전으로 반환하는 리액트 훅이에요. 이는 함수 실행을 지연시키고 여러 호출을 하나로 그룹화하여 이벤트 처리를 최적화하는 데 도움이 돼요.
 
 ## Interface
+
 ```ts
 function useDebouncedCallback(options: Object): Function;
-
 ```
 
 ### 파라미터
@@ -40,14 +40,12 @@ function useDebouncedCallback(options: Object): Function;
   description="콜백 호출을 지연시키는 디바운스된 함수예요."
 />
 
-
 ## 예시
 
 ```tsx
 function SearchInput() {
   const [query, setQuery] = useState('');
   const debouncedSetQuery = useDebouncedCallback({ onChange: setQuery, timeThreshold: 100 });
-  return <input type="text" onChange={(e) => debouncedSetQuery(e.target.value)} />;
+  return <input type="text" onChange={e => debouncedSetQuery(e.target.value)} />;
 }
 ```
-  

--- a/src/hooks/useDebouncedCallback/useDebouncedCallback.md
+++ b/src/hooks/useDebouncedCallback/useDebouncedCallback.md
@@ -3,9 +3,9 @@
 `useDebouncedCallback` is a React hook that returns a debounced version of the provided callback function. It helps optimize event handling by delaying function execution and grouping multiple calls into one.
 
 ## Interface
+
 ```ts
 function useDebouncedCallback(options: Object): Function;
-
 ```
 
 ### Parameters
@@ -40,14 +40,12 @@ function useDebouncedCallback(options: Object): Function;
   description="debounced function that delays invoking the callback."
 />
 
-
 ## Example
 
 ```tsx
 function SearchInput() {
   const [query, setQuery] = useState('');
   const debouncedSetQuery = useDebouncedCallback({ onChange: setQuery, timeThreshold: 100 });
-  return <input type="text" onChange={(e) => debouncedSetQuery(e.target.value)} />;
+  return <input type="text" onChange={e => debouncedSetQuery(e.target.value)} />;
 }
 ```
-  

--- a/src/hooks/useImpressionRef/ko/useImpressionRef.md
+++ b/src/hooks/useImpressionRef/ko/useImpressionRef.md
@@ -3,11 +3,9 @@
 `useImpressionRef`는 특정 DOM 요소가 화면에 보이는 시간을 측정하고 요소가 뷰포트에 들어오거나 나갈 때 콜백을 실행하는 커스텀 훅이에요. 이 훅은 `IntersectionObserver`와 `Visibility API`를 사용하여 요소의 가시성을 추적해요.
 
 ## 인터페이스
-```ts
-function useImpressionRef(
-  options: UseImpressionRefOptions,
-): (element: Element | null) => void;
 
+```ts
+function useImpressionRef(options: UseImpressionRefOptions): (element: Element | null) => void;
 ```
 
 ### 파라미터
@@ -60,7 +58,6 @@ function useImpressionRef(
   description="요소를 설정하기 위한 ref 함수예요. 이 함수를 <code>ref</code> 속성에 전달하면 해당 요소의 가시성이 변경될 때마다 콜백이 실행돼요."
 />
 
-
 ## 예시
 
 ```tsx
@@ -77,4 +74,3 @@ function Component() {
   return <div ref={ref}>내 가시성을 추적해 보세요!</div>;
 }
 ```
-  

--- a/src/hooks/useImpressionRef/useImpressionRef.md
+++ b/src/hooks/useImpressionRef/useImpressionRef.md
@@ -3,11 +3,9 @@
 `useImpressionRef` is a custom hook that measures the time a specific DOM element is visible on the screen and executes callbacks when the element enters or exits the viewport. This hook uses `IntersectionObserver` and the `Visibility API` to track the element's visibility.
 
 ## Interface
-```ts
-function useImpressionRef(
-  options: UseImpressionRefOptions,
-): (element: Element | null) => void;
 
+```ts
+function useImpressionRef(options: UseImpressionRefOptions): (element: Element | null) => void;
 ```
 
 ### Parameters
@@ -60,7 +58,6 @@ function useImpressionRef(
   description="function to set the element. Attach this function to the <code>ref</code> attribute, and the callbacks will be executed whenever the element's visibility changes."
 />
 
-
 ## Example
 
 ```tsx
@@ -77,4 +74,3 @@ function Component() {
   return <div ref={ref}>Track my visibility!</div>;
 }
 ```
-  

--- a/src/hooks/useInputState/ko/useInputState.md
+++ b/src/hooks/useInputState/ko/useInputState.md
@@ -3,12 +3,12 @@
 `useInputState`는 입력 상태를 관리하는 리액트 훅이에요. 선택적으로 값 변환 함수를 지정할 수도 있어요.
 
 ## 인터페이스
+
 ```ts
 function useInputState(
-  initialValue: string = "",
-  transformValue: (value: string) => string = (v: string) => v,
+  initialValue: string = '',
+  transformValue: (value: string) => string = (v: string) => v
 ): [value: string, onChange: (value: string) => void];
-
 ```
 
 ### 파라미터
@@ -45,7 +45,6 @@ function useInputState(
   ]"
 />
 
-
 ## 예시
 
 ```tsx
@@ -54,4 +53,3 @@ function Example() {
   return <input type="text" value={value} onChange={setValue} />;
 }
 ```
-  

--- a/src/hooks/useInputState/useInputState.md
+++ b/src/hooks/useInputState/useInputState.md
@@ -3,12 +3,12 @@
 `useInputState` is a React hook that manages an input state with optional value transformation.
 
 ## Interface
+
 ```ts
 function useInputState(
-  initialValue: string = "",
-  transformValue: (value: string) => string = (v: string) => v,
+  initialValue: string = '',
+  transformValue: (value: string) => string = (v: string) => v
 ): [value: string, onChange: (value: string) => void];
-
 ```
 
 ### Parameters
@@ -45,7 +45,6 @@ function useInputState(
   ]"
 />
 
-
 ## Example
 
 ```tsx
@@ -54,4 +53,3 @@ function Example() {
   return <input type="text" value={value} onChange={setValue} />;
 }
 ```
-  

--- a/src/hooks/useIntersectionObserver/ko/useIntersectionObserver.md
+++ b/src/hooks/useIntersectionObserver/ko/useIntersectionObserver.md
@@ -3,12 +3,12 @@
 `useIntersectionObserver`는 특정 DOM 요소가 화면에 보이는지를 감지하는 커스텀 훅이에요. 이 훅은 `IntersectionObserver` API를 사용하여 요소가 뷰포트에 들어오거나 나갈 때 콜백을 실행해요.
 
 ## 인터페이스
+
 ```ts
 function useIntersectionObserver(
   callback: (entry: IntersectionObserverEntry) => void,
-  options: IntersectionObserverInit,
+  options: IntersectionObserverInit
 ): (element: Element | null) => void;
-
 ```
 
 ### 파라미터
@@ -35,7 +35,6 @@ function useIntersectionObserver(
   description="요소를 설정하는 함수예요. 이 함수를 <code>ref</code> 속성에 첨부하면, 요소의 가시성이 변경될 때마다 <code>callback</code>이 실행돼요."
 />
 
-
 ## 예시
 
 ```tsx
@@ -56,4 +55,3 @@ function Component() {
   return <div ref={ref}>나를 관찰해요!</div>;
 }
 ```
-  

--- a/src/hooks/useIntersectionObserver/useIntersectionObserver.md
+++ b/src/hooks/useIntersectionObserver/useIntersectionObserver.md
@@ -3,12 +3,12 @@
 `useIntersectionObserver` is a custom hook that detects whether a specific DOM element is visible on the screen. This hook uses the `IntersectionObserver` API to execute a callback when the element enters or exits the viewport.
 
 ## Interface
+
 ```ts
 function useIntersectionObserver(
   callback: (entry: IntersectionObserverEntry) => void,
-  options: IntersectionObserverInit,
+  options: IntersectionObserverInit
 ): (element: Element | null) => void;
-
 ```
 
 ### Parameters
@@ -35,7 +35,6 @@ function useIntersectionObserver(
   description="function to set the element. Attach this function to the <code>ref</code> attribute, and the <code>callback</code> will be executed whenever the element's visibility changes."
 />
 
-
 ## Example
 
 ```tsx
@@ -56,4 +55,3 @@ function Component() {
   return <div ref={ref}>Observe me!</div>;
 }
 ```
-  

--- a/src/hooks/useInterval/ko/useInterval.md
+++ b/src/hooks/useInterval/ko/useInterval.md
@@ -3,12 +3,12 @@
 `useInterval`는 정해진 간격으로 함수를 실행하는 리액트 훅이에요. 타이머, 데이터 폴링 및 기타 반복 작업에 유용해요.
 
 ## 인터페이스
+
 ```ts
 function useInterval(
   callback: () => void,
-  options: number | { delay: number; enabled?: boolean; immediate?: boolean },
+  options: number | { delay: number; enabled?: boolean; immediate?: boolean }
 ): void;
-
 ```
 
 ### 파라미터
@@ -72,4 +72,3 @@ function Timer() {
   );
 }
 ```
-

--- a/src/hooks/useInterval/useInterval.md
+++ b/src/hooks/useInterval/useInterval.md
@@ -3,12 +3,12 @@
 `useInterval` is a React hook that executes a function at a specified interval. It is useful for timers, polling data, and other recurring tasks.
 
 ## Interface
+
 ```ts
 function useInterval(
   callback: () => void,
-  options: number | { delay: number; enabled?: boolean; immediate?: boolean },
+  options: number | { delay: number; enabled?: boolean; immediate?: boolean }
 ): void;
-
 ```
 
 ### Parameters
@@ -72,4 +72,3 @@ function Timer() {
   );
 }
 ```
-  

--- a/src/hooks/useLoading/ko/useLoading.md
+++ b/src/hooks/useLoading/ko/useLoading.md
@@ -3,16 +3,12 @@
 `useLoading`은 `Promise`의 로딩 상태 관리를 간소화하는 리액트 훅이에요. 비동기 작업이 진행 중인지 추적하는 상태와 로딩 상태를 자동으로 처리하는 함수를 제공해요.
 
 ## Interface
-```ts
-function useLoading(): [
-  loading: boolean,
-  startLoading: <T>(promise: Promise<T>) => Promise<T>,
-];
 
+```ts
+function useLoading(): [loading: boolean, startLoading: <T>(promise: Promise<T>) => Promise<T>];
 ```
 
 ### 파라미터
-
 
 ### 반환 값
 
@@ -36,7 +32,6 @@ function useLoading(): [
   ]"
 />
 
-
 ## 예시
 
 ```tsx
@@ -59,4 +54,3 @@ function ConfirmButton() {
   );
 }
 ```
-  

--- a/src/hooks/useLoading/useLoading.md
+++ b/src/hooks/useLoading/useLoading.md
@@ -3,16 +3,12 @@
 `useLoading` is a React hook that simplifies managing the loading state of a `Promise`. It provides a state to track whether an asynchronous operation is in progress and a function to handle the loading state automatically.
 
 ## Interface
-```ts
-function useLoading(): [
-  loading: boolean,
-  startLoading: <T>(promise: Promise<T>) => Promise<T>,
-];
 
+```ts
+function useLoading(): [loading: boolean, startLoading: <T>(promise: Promise<T>) => Promise<T>];
 ```
 
 ### Parameters
-
 
 ### Return Value
 
@@ -36,7 +32,6 @@ function useLoading(): [
   ]"
 />
 
-
 ## Example
 
 ```tsx
@@ -59,4 +54,3 @@ function ConfirmButton() {
   );
 }
 ```
-  

--- a/src/hooks/useOutsideClickEffect/ko/useOutsideClickEffect.md
+++ b/src/hooks/useOutsideClickEffect/ko/useOutsideClickEffect.md
@@ -3,12 +3,9 @@
 `useOutsideClickEffect`는 지정된 컨테이너 외부에서 클릭 이벤트가 발생할 때 콜백을 트리거하는 React 훅이에요. 모달, 드롭다운, 툴팁 및 다른 UI 컴포넌트를 외부 클릭 시 닫는 데 유용해요.
 
 ## 인터페이스
-```ts
-function useOutsideClickEffect(
-  container: HTMLElement | HTMLElement[] | null,
-  callback: () => void,
-): void;
 
+```ts
+function useOutsideClickEffect(container: HTMLElement | HTMLElement[] | null, callback: () => void): void;
 ```
 
 ### 파라미터
@@ -47,4 +44,3 @@ function Example() {
   return <div ref={setWrapperEl}>내용</div>;
 }
 ```
-  

--- a/src/hooks/useOutsideClickEffect/useOutsideClickEffect.md
+++ b/src/hooks/useOutsideClickEffect/useOutsideClickEffect.md
@@ -3,12 +3,9 @@
 `useOutsideClickEffect` is a React hook that triggers a callback when a click event occurs outside the specified container(s). It is useful for closing modals, dropdowns, tooltips, and other UI components when clicking outside.
 
 ## Interface
-```ts
-function useOutsideClickEffect(
-  container: HTMLElement | HTMLElement[] | null,
-  callback: () => void,
-): void;
 
+```ts
+function useOutsideClickEffect(container: HTMLElement | HTMLElement[] | null, callback: () => void): void;
 ```
 
 ### Parameters
@@ -47,4 +44,3 @@ function Example() {
   return <div ref={setWrapperEl}>Content</div>;
 }
 ```
-  

--- a/src/hooks/usePreservedCallback/usePreservedCallback.md
+++ b/src/hooks/usePreservedCallback/usePreservedCallback.md
@@ -3,11 +3,9 @@
 `usePreservedCallback` is a React hook that maintains a stable reference to a callback function while ensuring it always has access to the latest state or props. This prevents unnecessary re-renders and simplifies dependency management when passing callbacks to child components or handling event listeners.
 
 ## Interface
-```ts
-function usePreservedCallback(
-  callback: (...args: any[]) => any,
-): (...args: any[]) => any;
 
+```ts
+function usePreservedCallback(callback: (...args: any[]) => any): (...args: any[]) => any;
 ```
 
 ### Parameters
@@ -27,7 +25,6 @@ function usePreservedCallback(
   description="function with the same signature as the input callback. The returned function maintains a stable reference while accessing the latest state or props."
 />
 
-
 ## Example
 
 ```tsx
@@ -45,4 +42,3 @@ function Counter() {
   return <button onClick={handleClick}>Click me</button>;
 }
 ```
-  

--- a/src/hooks/useRefEffect/ko/useRefEffect.md
+++ b/src/hooks/useRefEffect/ko/useRefEffect.md
@@ -3,12 +3,12 @@
 `useRefEffect`는 특정 DOM 요소에 참조를 설정하고 요소가 변경될 때마다 콜백을 실행하는 데 도움을 주는 커스텀 훅이에요. 이 훅은 메모리 누수를 방지하기 위해 요소가 변경될 때마다 정리 함수를 호출해요.
 
 ## 인터페이스
+
 ```ts
 function useRefEffect(
   callback: (element: Element) => CleanupCallback | void,
-  deps: DependencyList,
+  deps: DependencyList
 ): (element: Element | null) => void;
-
 ```
 
 ### 파라미터
@@ -35,7 +35,6 @@ function useRefEffect(
   description="요소를 설정하는 함수예요. 이 함수를 <code>ref</code> 속성에 전달하면, 요소가 변경될 때마다 <code>callback</code>이 호출돼요."
 />
 
-
 ## 예시
 
 ```tsx
@@ -53,4 +52,3 @@ function Component() {
   return <div ref={ref}>기본 예시</div>;
 }
 ```
-  

--- a/src/hooks/useStorageState/ko/useStorageState.md
+++ b/src/hooks/useStorageState/ko/useStorageState.md
@@ -3,15 +3,12 @@
 리액트 훅으로, `useState`처럼 동작하지만 브라우저 저장소에 상태 값을 저장해요. 이 값은 페이지가 다시 로드되어도 유지되고, `localStorage`를 사용할 때 탭 간에 공유될 수 있어요.
 
 ## 인터페이스
+
 ```ts
 function useStorageState(
   key: string,
-  options: Object,
-): [
-  state: Serializable<T> | undefined,
-  setState: (value: SetStateAction<Serializable<T> | undefined>) => void,
-];
-
+  options: Object
+): [state: Serializable<T> | undefined, setState: (value: SetStateAction<Serializable<T> | undefined>) => void];
 ```
 
 ### 파라미터
@@ -67,7 +64,6 @@ function useStorageState(
   ]"
 />
 
-
 ## 예시
 
 ```tsx
@@ -82,4 +78,3 @@ function Counter() {
   return <button onClick={() => setCount(prev => prev + 1)}>Count: {count}</button>;
 }
 ```
-  

--- a/src/hooks/useStorageState/useStorageState.md
+++ b/src/hooks/useStorageState/useStorageState.md
@@ -3,15 +3,12 @@
 A React hook that functions like `useState` but persists the state value in browser storage. The value is retained across page reloads and can be shared between tabs when using `localStorage`.
 
 ## Interface
+
 ```ts
 function useStorageState(
   key: string,
-  options: Object,
-): [
-  state: Serializable<T> | undefined,
-  setState: (value: SetStateAction<Serializable<T> | undefined>) => void,
-];
-
+  options: Object
+): [state: Serializable<T> | undefined, setState: (value: SetStateAction<Serializable<T> | undefined>) => void];
 ```
 
 ### Parameters
@@ -67,7 +64,6 @@ function useStorageState(
   ]"
 />
 
-
 ## Example
 
 ```tsx
@@ -82,4 +78,3 @@ function Counter() {
   return <button onClick={() => setCount(prev => prev + 1)}>Count: {count}</button>;
 }
 ```
-  

--- a/src/hooks/useThrottle/ko/useThrottle.md
+++ b/src/hooks/useThrottle/ko/useThrottle.md
@@ -3,13 +3,13 @@
 리액트 훅이 콜백 함수의 쓰로틀 버전을 생성해요. 이는 스크롤 또는 리사이즈 이벤트를 처리할 때와 같이 함수가 호출되는 빈도를 제한하는 데 유용해요.
 
 ## 인터페이스
+
 ```ts
 function useThrottle<F>(
   callback: F,
   wait: number,
-  options: { edges?: Array<"leading" | "trailing"> },
+  options: { edges?: Array<'leading' | 'trailing'> }
 ): F & { cancel: () => void };
-
 ```
 
 ### 파라미터
@@ -52,13 +52,16 @@ function useThrottle<F>(
   description="보류 중인 실행을 취소하는 <code>cancel</code> 메서드를 가진 쓰로틀된 함수를 반환해요."
 />
 
-
 ## 예시
 
 ```tsx
-const throttledScroll = useThrottle(() => {
-  console.log('스크롤 이벤트');
-}, 200, { edges: ['leading', 'trailing'] });
+const throttledScroll = useThrottle(
+  () => {
+    console.log('스크롤 이벤트');
+  },
+  200,
+  { edges: ['leading', 'trailing'] }
+);
 
 useEffect(() => {
   window.addEventListener('scroll', throttledScroll);
@@ -68,4 +71,3 @@ useEffect(() => {
   };
 }, [throttledScroll]);
 ```
-  

--- a/src/hooks/useThrottle/useThrottle.md
+++ b/src/hooks/useThrottle/useThrottle.md
@@ -3,13 +3,13 @@
 A React hook that creates a throttled version of a callback function. This is useful for limiting the rate at which a function can be called, such as when handling scroll or resize events.
 
 ## Interface
+
 ```ts
 function useThrottle<F>(
   callback: F,
   wait: number,
-  options: { edges?: Array<"leading" | "trailing"> },
+  options: { edges?: Array<'leading' | 'trailing'> }
 ): F & { cancel: () => void };
-
 ```
 
 ### Parameters
@@ -52,13 +52,16 @@ function useThrottle<F>(
   description="Returns the throttled function with a <code>cancel</code> method to cancel pending executions."
 />
 
-
 ## Example
 
 ```tsx
-const throttledScroll = useThrottle(() => {
-  console.log('Scroll event');
-}, 200, { edges: ['leading', 'trailing'] });
+const throttledScroll = useThrottle(
+  () => {
+    console.log('Scroll event');
+  },
+  200,
+  { edges: ['leading', 'trailing'] }
+);
 
 useEffect(() => {
   window.addEventListener('scroll', throttledScroll);
@@ -68,4 +71,3 @@ useEffect(() => {
   };
 }, [throttledScroll]);
 ```
-  

--- a/src/hooks/useTimeout/ko/useTimeout.md
+++ b/src/hooks/useTimeout/ko/useTimeout.md
@@ -3,9 +3,9 @@
 `useTimeout`은 지정된 지연 시간 후에 콜백 함수를 실행하는 리액트 훅이에요. 리액트 생명 주기에 따라 `window.setTimeout`을 관리하며, 언마운트 시 또는 종속성이 변경될 때 정리가 보장돼요.
 
 ## 인터페이스
+
 ```ts
 function useTimeout(callback: () => void, delay: number = 0): void;
-
 ```
 
 ### 파라미터
@@ -48,4 +48,3 @@ function Example() {
   return <div>{title}</div>;
 }
 ```
-  

--- a/src/hooks/useTimeout/useTimeout.md
+++ b/src/hooks/useTimeout/useTimeout.md
@@ -3,9 +3,9 @@
 `useTimeout` is a React hook that executes a callback function after a specified delay. It manages `window.setTimeout` in accordance with the React lifecycle, ensuring cleanup on unmount or when dependencies change.
 
 ## Interface
+
 ```ts
 function useTimeout(callback: () => void, delay: number = 0): void;
-
 ```
 
 ### Parameters
@@ -48,4 +48,3 @@ function Example() {
   return <div>{title}</div>;
 }
 ```
-  

--- a/src/hooks/useToggle/ko/useToggle.md
+++ b/src/hooks/useToggle/ko/useToggle.md
@@ -3,11 +3,9 @@
 `useToggle`은 불리언 상태 관리를 간소화하는 리액트 훅이에요. 상태를 `true`와 `false` 사이에서 전환하는 함수를 제공해요.
 
 ## 인터페이스
-```ts
-function useToggle(
-  initialValue: boolean = false,
-): [state: boolean, toggle: () => void];
 
+```ts
+function useToggle(initialValue: boolean = false): [state: boolean, toggle: () => void];
 ```
 
 ### 파라미터
@@ -37,7 +35,6 @@ function useToggle(
     },
   ]"
 />
-
 
 ## 예시
 

--- a/src/hooks/useToggle/useToggle.md
+++ b/src/hooks/useToggle/useToggle.md
@@ -3,11 +3,9 @@
 `useToggle` is a React hook that simplifies managing a boolean state. It provides a function to toggle the state between `true` and `false`.
 
 ## Interface
-```ts
-function useToggle(
-  initialValue: boolean = false,
-): [state: boolean, toggle: () => void];
 
+```ts
+function useToggle(initialValue: boolean = false): [state: boolean, toggle: () => void];
 ```
 
 ### Parameters
@@ -38,7 +36,6 @@ function useToggle(
   ]"
 />
 
-
 ## Example
 
 ```tsx
@@ -55,4 +52,3 @@ function Component() {
   );
 }
 ```
-  

--- a/src/hooks/useVisibilityEvent/ko/useVisibilityEvent.md
+++ b/src/hooks/useVisibilityEvent/ko/useVisibilityEvent.md
@@ -3,12 +3,9 @@
 문서의 가시성 상태 변화를 감지하고 콜백을 트리거하는 React 훅이에요
 
 ## Interface
-```ts
-function useVisibilityEvent(
-  callback: (visibilityState: "visible" | "hidden") => void,
-  options: object,
-): void;
 
+```ts
+function useVisibilityEvent(callback: (visibilityState: 'visible' | 'hidden') => void, options: object): void;
 ```
 
 ### 파라미터
@@ -52,4 +49,3 @@ function Component() {
   return <p>가시성 변화를 콘솔에서 확인해요.</p>;
 }
 ```
-

--- a/src/hooks/useVisibilityEvent/useVisibilityEvent.md
+++ b/src/hooks/useVisibilityEvent/useVisibilityEvent.md
@@ -3,12 +3,9 @@
 A React hook that listens to changes in the document's visibility state and triggers a callback.
 
 ## Interface
-```ts
-function useVisibilityEvent(
-  callback: (visibilityState: "visible" | "hidden") => void,
-  options: object,
-): void;
 
+```ts
+function useVisibilityEvent(callback: (visibilityState: 'visible' | 'hidden') => void, options: object): void;
 ```
 
 ### Parameters
@@ -52,4 +49,3 @@ function Component() {
   return <p>Check the console for visibility changes.</p>;
 }
 ```
-  

--- a/src/utils/buildContext/buildContext.md
+++ b/src/utils/buildContext/buildContext.md
@@ -3,15 +3,12 @@
 `buildContext` is a helper function that reduces repetitive code when defining React Context.
 
 ## Interface
+
 ```ts
 function buildContext(
   contextName: string,
-  defaultContextValues: ContextValuesType,
-): [
-  Provider: (props: ProviderProps<ContextValuesType>) => JSX.Element,
-  useContext: () => ContextValuesType,
-];
-
+  defaultContextValues: ContextValuesType
+): [Provider: (props: ProviderProps<ContextValuesType>) => JSX.Element, useContext: () => ContextValuesType];
 ```
 
 ### Parameters
@@ -49,7 +46,6 @@ function buildContext(
   ]"
 />
 
-
 ## Example
 
 ```tsx
@@ -68,4 +64,3 @@ function Page() {
   );
 }
 ```
-  

--- a/src/utils/buildContext/ko/buildContext.md
+++ b/src/utils/buildContext/ko/buildContext.md
@@ -3,15 +3,12 @@
 `buildContext`는 React Context를 정의할 때 반복적인 코드를 줄여주는 도우미 함수예요.
 
 ## 인터페이스
+
 ```ts
 function buildContext(
   contextName: string,
-  defaultContextValues: ContextValuesType,
-): [
-  Provider: (props: ProviderProps<ContextValuesType>) => JSX.Element,
-  useContext: () => ContextValuesType,
-];
-
+  defaultContextValues: ContextValuesType
+): [Provider: (props: ProviderProps<ContextValuesType>) => JSX.Element, useContext: () => ContextValuesType];
 ```
 
 ### 파라미터
@@ -49,7 +46,6 @@ function buildContext(
   ]"
 />
 
-
 ## 예시
 
 ```tsx
@@ -68,4 +64,3 @@ function Page() {
   );
 }
 ```
-  

--- a/src/utils/mergeRefs/ko/mergeRefs.md
+++ b/src/utils/mergeRefs/ko/mergeRefs.md
@@ -3,11 +3,9 @@
 이 함수는 여러 개의 ref (RefObject 또는 RefCallback)를 받아서 제공된 모든 ref를 업데이트하는 단일 ref를 반환해요. 단일 요소에 여러 개의 ref를 전달해야 할 때 유용해요.
 
 ## 인터페이스
-```ts
-function mergeRefs(
-  refs: Array<RefObject<T> | RefCallback<T> | null | undefined>,
-): RefCallback<T>;
 
+```ts
+function mergeRefs(refs: Array<RefObject<T> | RefCallback<T> | null | undefined>): RefCallback<T>;
 ```
 
 ### 파라미터
@@ -27,7 +25,6 @@ function mergeRefs(
   description="제공된 모든 ref를 업데이트하는 단일 ref 콜백이에요."
 />
 
-
 ## 예시
 
 ```tsx
@@ -35,5 +32,5 @@ forwardRef(function Component(props, parentRef) {
   const myRef = useRef(null);
 
   return <div ref={mergeRefs(myRef, parentRef)} />;
-})
+});
 ```

--- a/src/utils/mergeRefs/mergeRefs.md
+++ b/src/utils/mergeRefs/mergeRefs.md
@@ -3,11 +3,9 @@
 This function takes multiple refs (RefObject or RefCallback) and returns a single ref that updates all provided refs. It's useful when you need to pass multiple refs to a single element.
 
 ## Interface
-```ts
-function mergeRefs(
-  refs: Array<RefObject<T> | RefCallback<T> | null | undefined>,
-): RefCallback<T>;
 
+```ts
+function mergeRefs(refs: Array<RefObject<T> | RefCallback<T> | null | undefined>): RefCallback<T>;
 ```
 
 ### Parameters
@@ -27,7 +25,6 @@ function mergeRefs(
   description="single ref callback that updates all provided refs."
 />
 
-
 ## Example
 
 ```tsx
@@ -35,6 +32,5 @@ forwardRef(function Component(props, parentRef) {
   const myRef = useRef(null);
 
   return <div ref={mergeRefs(myRef, parentRef)} />;
-})
+});
 ```
-  


### PR DESCRIPTION
# Overview

This PR applies consistent formatting across the codebase using the Prettier configuration defined in the project.  
All files were automatically formatted according to the rules (e.g., trailing commas, arrow function parentheses, etc.).  
There are no functional changes — this is purely a styling update to maintain code consistency.

If the following .prettierrc configuration is intentional:

```json
{
  "printWidth": 120,
  "singleQuote": true,
  "trailingComma": "es5",
  "tabWidth": 2,
  "arrowParens": "avoid"
}
```
then these formatting changes should be applied accordingly.


## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
