### PR TITLE
feat(useStorageState): add type definitions for storage state setters

### DIFF
--- a/src/hooks/useStorageState/useStorageState.ts
+++ b/src/hooks/useStorageState/useStorageState.ts
@@ -35,10 +35,10 @@ const emitListeners = () => {
  * @param {T} [options.defaultValue] - The initial value if no existing value is found.
  *
  * @returns {[
- *   state: Serializable<T> | undefined, 
- *   setState: StorageStateSetter<T> 
+ *   state: Serializable<T> | undefined,
+ *   setState: StorageStateSetter<T>
  * ] | [
- *   state: Serializable<T>, 
+ *   state: Serializable<T>,
  *   setState: RequiredStorageStateSetter<T>
  * ]} A tuple:
  * - state `Serializable<T> | undefined` - The current state value retrieved from storage;

--- a/src/hooks/useStorageState/useStorageState.ts
+++ b/src/hooks/useStorageState/useStorageState.ts
@@ -34,9 +34,19 @@ const emitListeners = () => {
  * @param {Storage} [options.storage=localStorage] - The storage type (`localStorage` or `sessionStorage`). Defaults to `localStorage`.
  * @param {T} [options.defaultValue] - The initial value if no existing value is found.
  *
- * @returns {[state: Serializable<T> | undefined, setState: (value: SetStateAction<Serializable<T> | undefined>) => void]} A tuple:
+ * @returns {[
+ *   state: Serializable<T> | undefined, 
+ *   setState: StorageStateSetter<T> 
+ * ] | [
+ *   state: Serializable<T>, 
+ *   setState: RequiredStorageStateSetter<T>
+ * ]} A tuple:
  * - state `Serializable<T> | undefined` - The current state value retrieved from storage;
- * - setState `(value: SetStateAction<Serializable<T> | undefined>) => void` - A function to update and persist the state;
+ * - setState `StorageStateSetter<T>` - A function to update and persist the state when `defaultValue` is not provided or state can be `undefined`.
+ * 
+ * When `defaultValue` is provided:
+ * - state `Serializable<T>` - The current state value retrieved from storage (must exist);
+ * - setState `RequiredStorageStateSetter<T>` - A function to update and persist the state when `defaultValue` is provided (state cannot be `undefined`).
  *
  * @example
  * // Counter with persistent state
@@ -50,7 +60,6 @@ const emitListeners = () => {
  *   return <button onClick={() => setCount(prev => prev + 1)}>Count: {count}</button>;
  * }
  */
-
 export function useStorageState<T>(
   key: string
 ): readonly [Serializable<T> | undefined, StorageStateSetter<T>];

--- a/src/hooks/useStorageState/useStorageState.ts
+++ b/src/hooks/useStorageState/useStorageState.ts
@@ -11,10 +11,12 @@ type StorageStateOptions<T> = {
   storage?: Storage;
   defaultValue?: Serializable<T>;
 };
-
 type StorageStateOptionsWithDefaultValue<T> = StorageStateOptions<T> & {
   defaultValue: Serializable<T>;
 };
+
+type StorageStateSetter<T> = (value: SetStateAction<Serializable<T> | undefined>) => void;
+type RequiredStorageStateSetter<T> = (value: SetStateAction<Serializable<T>>) => void;
 
 const listeners = new Set<() => void>();
 
@@ -48,21 +50,22 @@ const emitListeners = () => {
  *   return <button onClick={() => setCount(prev => prev + 1)}>Count: {count}</button>;
  * }
  */
+
 export function useStorageState<T>(
   key: string
-): readonly [Serializable<T> | undefined, (value: SetStateAction<Serializable<T> | undefined>) => void];
+): readonly [Serializable<T> | undefined, StorageStateSetter<T>];
 export function useStorageState<T>(
   key: string,
   { storage, defaultValue }: StorageStateOptionsWithDefaultValue<T>
-): readonly [Serializable<T>, (value: SetStateAction<Serializable<T>>) => void];
+): readonly [Serializable<T>, RequiredStorageStateSetter<T>];
 export function useStorageState<T>(
   key: string,
   { storage, defaultValue }: StorageStateOptions<T>
-): readonly [Serializable<T> | undefined, (value: SetStateAction<Serializable<T> | undefined>) => void];
+): readonly [Serializable<T> | undefined, StorageStateSetter<T>];
 export function useStorageState<T>(
   key: string,
   { storage = safeLocalStorage, defaultValue }: StorageStateOptions<T> = {}
-): readonly [Serializable<T> | undefined, (value: SetStateAction<Serializable<T> | undefined>) => void] {
+): readonly [Serializable<T> | undefined, StorageStateSetter<T>] {
   const cache = useRef<{
     data: string | null;
     parsed: Serializable<T> | undefined;

--- a/src/hooks/useStorageState/useStorageState.ts
+++ b/src/hooks/useStorageState/useStorageState.ts
@@ -34,15 +34,10 @@ const emitListeners = () => {
  * @param {Storage} [options.storage=localStorage] - The storage type (`localStorage` or `sessionStorage`). Defaults to `localStorage`.
  * @param {T} [options.defaultValue] - The initial value if no existing value is found.
  *
- * @returns {[
- *   state: Serializable<T> | undefined,
- *   setState: StorageStateSetter<T>
- * ] | [
- *   state: Serializable<T>,
- *   setState: RequiredStorageStateSetter<T>
- * ]} A tuple:
- * - state `Serializable<T> | undefined` - The current state value retrieved from storage;
- * - setState `StorageStateSetter<T>` - A function to update and persist the state when `defaultValue` is not provided or state can be `undefined`.
+ * @returns {readonly [Serializable<T> | undefined, StorageStateSetter<T>] 
+ * | readonly [Serializable<T>, RequiredStorageStateSetter<T>]} A tuple:
+ * - state: the current state value retrieved from storage;
+ * - setState: function to update and persist the state;
  *
  * When `defaultValue` is provided:
  * - state `Serializable<T>` - The current state value retrieved from storage (must exist);

--- a/src/hooks/useStorageState/useStorageState.ts
+++ b/src/hooks/useStorageState/useStorageState.ts
@@ -34,8 +34,8 @@ const emitListeners = () => {
  * @param {Storage} [options.storage=localStorage] - The storage type (`localStorage` or `sessionStorage`). Defaults to `localStorage`.
  * @param {T} [options.defaultValue] - The initial value if no existing value is found.
  *
- * @returns {readonly [Serializable<T> | undefined, StorageStateSetter<T>] 
- * | readonly [Serializable<T>, RequiredStorageStateSetter<T>]} A tuple:
+ * @returns {readonly [Serializable<T>, RequiredStorageStateSetter<T>] | readonly [Serializable<T> | undefined, StorageStateSetter<T>]} A tuple with state and setState function, depending on whether defaultValue is provided.
+ *
  * - state: the current state value retrieved from storage;
  * - setState: function to update and persist the state;
  *

--- a/src/hooks/useStorageState/useStorageState.ts
+++ b/src/hooks/useStorageState/useStorageState.ts
@@ -43,7 +43,7 @@ const emitListeners = () => {
  * ]} A tuple:
  * - state `Serializable<T> | undefined` - The current state value retrieved from storage;
  * - setState `StorageStateSetter<T>` - A function to update and persist the state when `defaultValue` is not provided or state can be `undefined`.
- * 
+ *
  * When `defaultValue` is provided:
  * - state `Serializable<T>` - The current state value retrieved from storage (must exist);
  * - setState `RequiredStorageStateSetter<T>` - A function to update and persist the state when `defaultValue` is provided (state cannot be `undefined`).
@@ -60,9 +60,7 @@ const emitListeners = () => {
  *   return <button onClick={() => setCount(prev => prev + 1)}>Count: {count}</button>;
  * }
  */
-export function useStorageState<T>(
-  key: string
-): readonly [Serializable<T> | undefined, StorageStateSetter<T>];
+export function useStorageState<T>(key: string): readonly [Serializable<T> | undefined, StorageStateSetter<T>];
 export function useStorageState<T>(
   key: string,
   { storage, defaultValue }: StorageStateOptionsWithDefaultValue<T>


### PR DESCRIPTION
# Overview

Improved type definitions for the state setter in `useStorageState` hook.

The setter types were previously duplicated or unclear.
So, `StorageStateSetter` and `RequiredStorageStateSetter` were added. This helps to clearly separate the setters based on whether the state can be undefined, reducing duplicated code.

```ts
// Setter for states that can be undefined.

type StorageStateSetter<T> = (value: SetStateAction<Serializable<T> | undefined>) => void;
```

```ts
// Setter for states that are required and cannot be undefined.

type RequiredStorageStateSetter<T> = (value: SetStateAction<Serializable<T> | undefined>) => void;
```

In my opinion, this improves type safety, readability, and maintainability.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
