### PR TITLE
docs: update link for 'Reference'

### DIFF
--- a/.vitepress/en.mts
+++ b/.vitepress/en.mts
@@ -23,7 +23,7 @@ function nav(): DefaultTheme.NavItem[] {
   return [
     { text: 'Home', link: '/' },
     { text: 'Introduction', link: '/intro.html' },
-    { text: 'Reference', link: '/hooks/useBooleanState.html' },
+    { text: 'Reference', link: '/components/ImpressionArea.html' },
   ];
 }
 

--- a/.vitepress/ko.mts
+++ b/.vitepress/ko.mts
@@ -23,7 +23,7 @@ function nav(): DefaultTheme.NavItem[] {
   return [
     { text: '홈', link: '/ko' },
     { text: '소개', link: '/ko/intro.html' },
-    { text: '레퍼런스', link: '/ko/hooks/useBooleanState.html' },
+    { text: '레퍼런스', link: '/ko/components/ImpressionArea.html' },
   ];
 }
 

--- a/src/docs/en/index.md
+++ b/src/docs/en/index.md
@@ -13,7 +13,7 @@ hero:
       link: /intro.html
     - theme: alt
       text: Reference
-      link: /hooks/useBooleanState.html
+      link: /components/ImpressionArea.html
     - theme: alt
       text: Installation
       link: /installation.html

--- a/src/docs/ko/index.md
+++ b/src/docs/ko/index.md
@@ -13,7 +13,7 @@ hero:
       link: /ko/intro.html
     - theme: alt
       text: 레퍼런스
-      link: /ko/hooks/useBooleanState.html
+      link: /ko/components/ImpressionArea.html
     - theme: alt
       text: 설치하기
       link: /ko/installation.html


### PR DESCRIPTION
# Overview

Fix the reference link in the header and navigation so that it now navigates to `components/ImpressionArea.html` at the top level instead of `hooks/useBooleanState.html`.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
