### PR TITLE
docs: useAsyncEffect documentation Clarify behavior when deps are omitted

### DIFF
--- a/src/hooks/useAsyncEffect/ko/useAsyncEffect.md
+++ b/src/hooks/useAsyncEffect/ko/useAsyncEffect.md
@@ -13,7 +13,7 @@ function useAsyncEffect(effect: () => Promise<void | (() => void)>, deps: Depend
 <Interface
   name="effect"
   type="() => Promise<void | (() => void)>"
-  description="<code>useEffect</code> 패턴으로 실행되는 비동기 함수예요. 이 함수는 선택적으로 정리(cleanup) 함수를 반환할 수 있어요."
+  description="<code>useEffect</code> 패턴으로 실행되는 비동기 함수예요. 이 함수는 선택적으로 정리(clean-up) 함수를 반환할 수 있어요."
 />
 
 <Interface

--- a/src/hooks/useAsyncEffect/ko/useAsyncEffect.md
+++ b/src/hooks/useAsyncEffect/ko/useAsyncEffect.md
@@ -19,7 +19,7 @@ function useAsyncEffect(effect: () => Promise<void | (() => void)>, deps: Depend
 <Interface
   name="deps"
   type="DependencyList"
-  description="의존성 배열이에요. 이 배열의 값이 변경될 때마다 효과가 다시 실행돼요. 만약 생략하면, 컴포넌트가 마운트될 때만 한 번 실행돼요."
+  description="의존성 배열이에요. 이 배열의 값이 변경될 때마다 효과가 다시 실행돼요. 만약 생략하면, 컴포넌트가 리렌더링 될 때마다 실행돼요."
 />
 
 ### 반환 값

--- a/src/hooks/useAsyncEffect/useAsyncEffect.md
+++ b/src/hooks/useAsyncEffect/useAsyncEffect.md
@@ -19,7 +19,7 @@ function useAsyncEffect(effect: () => Promise<void | (() => void)>, deps: Depend
 <Interface
   name="deps"
   type="DependencyList"
-  description="A dependency array. The effect will re-run whenever any value in this array changes. If omitted, it runs only once when the component mounts."
+  description="A dependency array. The effect will re-run whenever any value in this array changes. If omitted, the effect will run on every component re-render."
 />
 
 ### Return Value


### PR DESCRIPTION
This PR addresses two issues in the useAsyncEffect documentation:

1. Corrects the description of the effect's behavior when the dependency array is omitted.
Previously, it incorrectly stated that the effect would run only once when the component mounts.
The correct behavior is that the effect runs on every re-render when deps are omitted.

This is evidenced by the following test case:
```ts
it('should call effect every rerender when deps are undefined', async () => {
  const effect = vi.fn().mockResolvedValue(undefined);

  const { rerender } = await renderHookSSR(() => useAsyncEffect(effect));

  await flushPromises();

  expect(effect).toHaveBeenCalled();

  rerender();

  expect(effect).toHaveBeenCalledTimes(2);

  rerender();
  expect(effect).toHaveBeenCalledTimes(3);
});
```

2. Improves consistency in terminology by changing "cleanup" to "clean-up" throughout the documentation.
This aligns with the earlier use of "clean-up" in the hook's description.

These changes enhance the accuracy and consistency of the useAsyncEffect documentation,
providing developers with clearer guidance on the hook's behavior.

## Checklist

- [X] Did you write the test code?
- [X] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [X] Did you write the JSDoc?
