### PR TITLE
refactor(hooks): add 'readonly' type modifier to '@returns' in JSDoc

### DIFF
--- a/src/hooks/useBooleanState/useBooleanState.ts
+++ b/src/hooks/useBooleanState/useBooleanState.ts
@@ -7,7 +7,7 @@ import { useCallback, useState } from 'react';
  *
  * @param {boolean} [defaultValue=false] - The initial value of the state. Defaults to `false`.
  *
- * @returns {[state: boolean, setTrue: () => void, setFalse: () => void, toggle: () => void]} A tuple containing:
+ * @returns {readonly [state: boolean, setTrue: () => void, setFalse: () => void, toggle: () => void]} A tuple containing:
  * - state `boolean` - The current state value;
  * - setTrue `() => void` - A function to set the state to `true`;
  * - setFalse `() => void` - A function to set the state to `false`;

--- a/src/hooks/useStorageState/useStorageState.ts
+++ b/src/hooks/useStorageState/useStorageState.ts
@@ -32,7 +32,7 @@ const emitListeners = () => {
  * @param {Storage} [options.storage=localStorage] - The storage type (`localStorage` or `sessionStorage`). Defaults to `localStorage`.
  * @param {T} [options.defaultValue] - The initial value if no existing value is found.
  *
- * @returns {[state: Serializable<T> | undefined, setState: (value: SetStateAction<Serializable<T> | undefined>) => void]} A tuple:
+ * @returns {readonly [state: Serializable<T> | undefined, setState: (value: SetStateAction<Serializable<T> | undefined>) => void]} A tuple:
  * - state `Serializable<T> | undefined` - The current state value retrieved from storage;
  * - setState `(value: SetStateAction<Serializable<T> | undefined>) => void` - A function to update and persist the state;
  *


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
