### PR TITLE
refactor(useStorageState): rename param 'value' to 'nextValue' in 'setStorageState'

### DIFF
--- a/src/hooks/useStorageState/useStorageState.ts
+++ b/src/hooks/useStorageState/useStorageState.ts
@@ -108,13 +108,13 @@ export function useStorageState<T>(
   );
 
   const setStorageState = useCallback(
-    (value: SetStateAction<Serializable<T> | undefined>) => {
-      const nextValue = typeof value === 'function' ? value(getSnapshot()) : value;
+    (nextValue: SetStateAction<Serializable<T> | undefined>) => {
+      const value = typeof nextValue === 'function' ? nextValue(getSnapshot()) : nextValue;
 
-      if (nextValue == null) {
+      if (value == null) {
         storage.remove(key);
       } else {
-        storage.set(key, JSON.stringify(nextValue));
+        storage.set(key, JSON.stringify(value));
       }
       emitListeners();
     },


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

* The variable name value in the `setStorageState` function of the `useStorageState` hook has been changed to `nextValue`. This change is made to align with React’s `setState` pattern.
  * In `setState`, the parameter passed is typically named `nextValue`, following the naming convention used in the function update pattern.
  * The name value represents the value being handled inside `setStorageState`, and renaming it to `nextValue` ensures consistency with React’s `useState` and `setState` functions.

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
