### PR TITLE
chore(*): unify the format of '.prettierrc' and the result of 'generateDocs'

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,13 @@
   "singleQuote": true,
   "trailingComma": "es5",
   "tabWidth": 2,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "printWidth": 80
+      }
+    }
+  ]
 }

--- a/.scripts/commands/generateDocs/index.ts
+++ b/.scripts/commands/generateDocs/index.ts
@@ -11,6 +11,14 @@ import { translate } from './translate.ts';
 
 type Spec = Pick<OriginSpec, 'type' | 'name' | 'description' | 'optional' | 'default'>;
 
+const prettierConfig: prettier.Options = {
+  printWidth: 80,
+  singleQuote: true,
+  trailingComma: 'es5',
+  tabWidth: 2,
+  arrowParens: 'avoid',
+};
+
 export async function generateDocs(names: string[]) {
   const tasks = new Listr([], { concurrent: 10 });
 
@@ -193,27 +201,26 @@ async function jsdocToMd(name: string, jsdoc: ReturnType<typeof parseJSDoc>) {
 ${description}
 
 ## Interface
+
 \`\`\`ts
-${await prettier.format(`function ${name}${getTemplateCode()}(${getParamsCode()}): ${returns == null ? 'void' : returns.type};`, { parser: 'typescript' })}
-\`\`\`
+${await prettier.format(`function ${name}${getTemplateCode()}(${getParamsCode()}): ${returns == null ? 'void' : returns.type};`, { ...prettierConfig, parser: 'typescript' })}\`\`\`
 
 ### Parameters
 
-${await prettier.format(paramsProps.map(props => getParamUl(...props)).join(''), { parser: 'vue' })}
+${await prettier.format(paramsProps.map(props => getParamUl(...props)).join(''), { ...prettierConfig, parser: 'vue' })}
 ### Return Value
 ${
   returns == null
     ? '\nThis hook does not return anything.'
     : `
-${await prettier.format(getParamUl(returns, nestedValueOfReturns), { parser: 'vue' })}`
+${await prettier.format(getParamUl(returns, nestedValueOfReturns), { ...prettierConfig, parser: 'vue' })}`
 }
-
 ## Example
 
 \`\`\`tsx
 ${example}
 \`\`\`
-  `;
+`;
 }
 
 function getParamUl(param: Spec, nestedParams?: Spec[]) {


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

* In `generateDoc`, the document is generated using `prettier.format` with the default config, To ensure consistency across the code, adding our `.prettierrc` config in `prettier.format` in `.script/commands/generateDocs/index.ts`. This could help resolve issues like https://github.com/toss/react-simplikit/pull/123#issuecomment-2799779862.
* About the result of `generateDoc`, we need to check it

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
