### PR TITLE
fix: Remove unnecessary vertical scrollbar and improve the example with tab format in "Rendering Arrays with Specific Separators" section

### DIFF
--- a/src/docs/en/intro.md
+++ b/src/docs/en/intro.md
@@ -31,9 +31,7 @@ function Page() {
 
 ### Rendering Arrays with Specific Separators
 
-<SplitView>
-  <template #left>
-
+::: code-group
 ```tsx [without-react-simplikit.tsx]
 const texts = ['hello', 'react', 'world'];
 
@@ -53,10 +51,6 @@ function Page() {
 }
 ```
 
-  </template>
-
-<template #right>
-
 ```tsx [without-react-simplikit.tsx]
 const texts = ['hello', 'react', 'world'];
 
@@ -70,9 +64,7 @@ function Page() {
   );
 }
 ```
-
-  </template>
-</SplitView>
+:::
 
 ## Minimizing Unintended Behavior and Bugs with Concise Implementation
 

--- a/src/docs/ko/intro.md
+++ b/src/docs/ko/intro.md
@@ -31,9 +31,7 @@ function Page() {
 
 ### 특정 요소로 구분하여 배열 렌더링하기
 
-<SplitView>
-  <template #left>
-
+::: code-group
 ```tsx [without-react-simplikit.tsx]
 const texts = ['hello', 'react', 'world'];
 
@@ -53,10 +51,6 @@ function Page() {
 }
 ```
 
-  </template>
-
-<template #right>
-
 ```tsx [without-react-simplikit.tsx]
 const texts = ['hello', 'react', 'world'];
 
@@ -70,9 +64,7 @@ function Page() {
   );
 }
 ```
-
-  </template>
-</SplitView>
+:::
 
 ## 간결한 구현으로, 의도하지 않은 동작이나 버그를 최소화해요
 


### PR DESCRIPTION
# Overview

This PR remove unnecessary vertical scrollbar and improve the example with tab format in "Rendering Arrays with Specific Separators" section

- Fixed the issue causing an unwanted vertical scrollbar to appear on the right side of the code block.
- Refactored the example code by separating without-react-simplikit.tsx and with-react-simplikit.tsx into tabs for better readability.

**Before**
<img width="1139" alt="스크린샷 2025-04-15 오전 10 15 38" src="https://github.com/user-attachments/assets/2aab1370-0668-4931-b7fd-cef0b7d5fc3a" />

**After**
<img width="1139" alt="스크린샷 2025-04-15 오전 10 15 59" src="https://github.com/user-attachments/assets/57657e66-833b-48f7-987a-cc0c90980e9f" />


## Checklist
- [ ] Did you write the test code?
- [ ] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
