### PR TITLE
docs(docs/**/intro): unify kr and en docs, add printWidth to 70 in '**/intro.md' in '.prettierrc'

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,5 +11,3 @@ esm
 out
 *.d.ts
 *.tgz
-
-src/docs/en

--- a/.prettierrc
+++ b/.prettierrc
@@ -10,6 +10,12 @@
       "options": {
         "printWidth": 80
       }
+    },
+    {
+      "files": "**/intro.md",
+      "options": {
+        "printWidth": 70
+      }
     }
   ]
 }

--- a/src/docs/en/intro.md
+++ b/src/docs/en/intro.md
@@ -37,7 +37,7 @@ right-title="with-react-simplikit.tsx">
 
 <template #left>
 
-```tsx 
+```tsx
 // without react simplikit
 const texts = ['hello', 'react', 'world'];
 
@@ -46,9 +46,9 @@ function Page() {
     <>
       {texts.map((text, idx) => (
         <Fragment key={text}>
-          <div>{text}</div>
-          {idx < texts.length - 1 
-          : null}
+          {idx < texts.length - 1 ? (
+            <Border type="padding24" />
+          ) : null}
         </Fragment>
       ))}
     </>
@@ -60,7 +60,7 @@ function Page() {
 
 <template #right>
 
-```tsx 
+```tsx
 // without react simplikit
 const texts = ['hello', 'react', 'world'];
 

--- a/src/docs/ko/intro.md
+++ b/src/docs/ko/intro.md
@@ -31,10 +31,14 @@ function Page() {
 
 ### 특정 요소로 구분하여 배열 렌더링하기
 
-<SplitView>
-  <template #left>
+<SplitView 
+left-title="without-react-simplikit.tsx"
+right-title="with-react-simplikit.tsx">
 
-```tsx [without-react-simplikit.tsx]
+<template #left>
+
+```tsx
+// without react simplikit
 const texts = ['hello', 'react', 'world'];
 
 function Page() {
@@ -42,7 +46,6 @@ function Page() {
     <>
       {texts.map((text, idx) => (
         <Fragment key={text}>
-          <div>{text}</div>
           {idx < texts.length - 1 ? (
             <Border type="padding24" />
           ) : null}
@@ -57,7 +60,8 @@ function Page() {
 
 <template #right>
 
-```tsx [without-react-simplikit.tsx]
+```tsx
+// without react simplikit
 const texts = ['hello', 'react', 'world'];
 
 function Page() {


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

* relate https://github.com/toss/react-simplikit/pull/173
* relate https://github.com/toss/react-simplikit/pull/123#issuecomment-2799779862
* `intro.md`s are applyed by `prettier`

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
