### PR TITLE
feat(mergeProps): add mergeProps util function

### DIFF
--- a/src/utils/mergeProps/index.ts
+++ b/src/utils/mergeProps/index.ts
@@ -1,0 +1,1 @@
+export { mergeProps } from './mergeProps.ts';

--- a/src/utils/mergeProps/mergeProps.spec.ts
+++ b/src/utils/mergeProps/mergeProps.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeProps } from './mergeProps.ts';
+
+describe('mergeProps', () => {
+  it('should return the same props when a single set of props is passed', () => {
+    const props = {
+      onClick: () => {},
+      onKeyDown: () => {},
+      className: 'className',
+    };
+
+    expect(mergeProps(props)).toEqual(props);
+  });
+
+  it('should combine props of different names', () => {
+    const onClick = () => {};
+    const onFocus = () => {};
+    const onKeyDown = () => {};
+
+    const props = mergeProps({ onClick }, { onFocus }, { onKeyDown });
+
+    expect(props).toHaveProperty('onClick', onClick);
+    expect(props).toHaveProperty('onFocus', onFocus);
+    expect(props).toHaveProperty('onKeyDown', onKeyDown);
+  });
+
+  it('should concatenate classNames', () => {
+    const props = mergeProps({ className: 'one' }, { className: 'two' });
+    expect(props).toHaveProperty('className', 'one two');
+  });
+
+  it('should merge styles', () => {
+    const props = mergeProps({ style: { display: 'none' } }, { style: { color: 'red' } });
+    expect(props).toHaveProperty('style', { display: 'none', color: 'red' });
+  });
+
+  it('should call duplicate event handlers in sequence', () => {
+    let tape = '';
+    const one = () => (tape += 'one ');
+    const two = () => (tape += 'two ');
+    const three = () => (tape += 'three');
+    mergeProps({ onClick: one }, { onClick: two }, { onClick: three }).onClick();
+
+    expect(tape).toBe('one two three');
+  });
+
+  it('should pass arguments to functions', () => {
+    const argsCalled = {
+      one: [null],
+      two: [null],
+    };
+
+    const one = (...args: any[]) => (argsCalled.one = args);
+    const two = (...args: any[]) => (argsCalled.two = args);
+    const args = [{}, {}];
+    mergeProps({ onClick: one }, { onClick: two }).onClick(...args);
+
+    expect(argsCalled.one[0]).toBe(args[0]);
+    expect(argsCalled.one[1]).toBe(args[1]);
+    expect(argsCalled.two[0]).toBe(args[0]);
+    expect(argsCalled.two[1]).toBe(args[1]);
+  });
+
+  it('should pass through the first instance of unknown prop', () => {
+    const unknown = {};
+    expect(mergeProps({ unknown }).unknown).toBe(unknown);
+  });
+
+  it('should skip undefined functions', () => {
+    let tape = '';
+    const one = () => (tape += 'only one');
+
+    const props = mergeProps({ onClick: one }, { onClick: undefined } as { onClick?: () => void });
+    expect(props.onClick()).toBe('only one');
+  });
+
+  it('should skip undefined values', () => {
+    expect(mergeProps({ isDisabled: undefined }, { isDisabled: true }, { isDisabled: undefined })).toStrictEqual({
+      isDisabled: true,
+    });
+  });
+
+  it('should return empty object when no input passed', () => {
+    expect(mergeProps()).toEqual({});
+  });
+});

--- a/src/utils/mergeProps/mergeProps.ts
+++ b/src/utils/mergeProps/mergeProps.ts
@@ -1,0 +1,71 @@
+import type { CSSProperties } from 'react';
+
+type BaseProps = {
+  style?: CSSProperties;
+  [key: string]: unknown;
+};
+
+type TupleToIntersection<T extends Record<string, unknown>[]> = {
+  [I in keyof T]: (x: T[I]) => void;
+}[number] extends (x: infer I) => void
+  ? I
+  : never;
+
+/**
+ * @description
+ * `mergeProps` is a utility function that merges multiple props objects into a single object.
+ * It handles merging of `className`, `style`, and `function` properties.
+ *
+ * @template PropsList - The type of the props objects to merge.
+ *
+ * @param {PropsList} props - The props objects to merge.
+ * @returns {TupleToIntersection<PropsList>} The merged props object.
+ *
+ * @example
+ * const mergedProps = mergeProps({ className: 'foo', style: { color: 'red' } }, { className: 'bar', style: { backgroundColor: 'blue' } });
+ * console.log(mergedProps); // { className: 'foo bar', style: { color: 'red', backgroundColor: 'blue' } }
+ */
+export function mergeProps<PropsList extends BaseProps[]>(...props: PropsList): TupleToIntersection<PropsList> {
+  return props.reduce(pushProp, {}) as TupleToIntersection<PropsList>;
+}
+
+function pushProp(prev: BaseProps, curr: BaseProps): BaseProps {
+  for (const key in curr) {
+    if (curr[key] === undefined) continue;
+
+    switch (key) {
+      case 'className': {
+        prev[key] = [prev[key], curr[key]].join(' ').trim();
+        break;
+      }
+      case 'style': {
+        prev[key] = mergeStyle(prev[key], curr[key]);
+        break;
+      }
+      default: {
+        const mergedFunction = mergeFunction(prev[key], curr[key]);
+
+        if (mergedFunction) {
+          prev[key] = mergedFunction;
+        } else if (curr[key] !== undefined) {
+          prev[key] = curr[key];
+        }
+      }
+    }
+  }
+  return prev;
+}
+
+function mergeStyle(a?: CSSProperties, b?: CSSProperties): CSSProperties | undefined {
+  if (a == null) return b;
+  return { ...a, ...b };
+}
+
+function mergeFunction(a: unknown, b: unknown): ((...args: unknown[]) => void) | undefined {
+  if (typeof a === 'function' && typeof b === 'function') {
+    return (...args: unknown[]) => {
+      a(...args);
+      b(...args);
+    };
+  }
+}


### PR DESCRIPTION
# Overview
Implementation of: https://github.com/toss/react-simplikit/issues/163

This PR introduces the `mergeProps` utility function, which merges multiple props objects into a single one. It intelligently handles merging of className, style, and function properties:

- className values are concatenated with space delimiters.
- style objects are shallowly merged.
- If both previous and current values are functions, they are composed into a single function that calls both sequentially.

This utility helps maintain cleaner JSX and more reusable component logic when combining props across layers of abstraction.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
