### PR TITLE
docs: update bundle size section

### DIFF
--- a/src/docs/en/why-react-simplikit-matters.md
+++ b/src/docs/en/why-react-simplikit-matters.md
@@ -199,7 +199,7 @@ Compared to `react-use`, `react-simplikit` has up to about 89% smaller size:
 
 |                                               | react-simplikit                                                   | react-use                                                    | Difference |
 | --------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------ | ---------- |
-| Unpacked Size                                 | [131 kB](https://www.npmjs.com/package/react-simplikit)           | [454 kB](https://www.npmjs.com/package/react-use)            | -71.1%     |
-| Minified Size                                 | [8.5 kB](https://bundlephobia.com/package/react-simplikit@0.2.27) | [78.2 kB](https://bundlephobia.com/package/react-use@17.6.0) | -89.1%     |
-| Gzipped Size                                  | [2.8 kB](https://bundlephobia.com/package/react-simplikit@0.2.27) | [22 kB](https://bundlephobia.com/package/react-use@17.6.0)   | -87.2%     |
-| Average Size per Function<br/>(Minified Size) | 350 byte                                                          | 680 byte                                                     | -48.5%     |
+| Unpacked Size                                 | [237 kB](https://www.npmjs.com/package/react-simplikit)           | [454 kB](https://www.npmjs.com/package/react-use)            | -47.8%     |
+| Minified Size                                 | [8.7 kB](https://bundlephobia.com/package/react-simplikit@0.0.29) | [78.2 kB](https://bundlephobia.com/package/react-use@17.6.0) | -88.9%     |
+| Gzipped Size                                  | [2.9 kB](https://bundlephobia.com/package/react-simplikit@0.0.29) | [22 kB](https://bundlephobia.com/package/react-use@17.6.0)   | -86.9%     |
+| Average Size per Function<br/>(Minified Size) | 318.2 byte                                                          | 696.3 byte                                                     | -54.3%     |

--- a/src/docs/ko/why-react-simplikit-matters.md
+++ b/src/docs/ko/why-react-simplikit-matters.md
@@ -199,7 +199,7 @@ function AutoCompleteInput() {
 
 |                                            | react-simplikit                                                  | react-use                                                    | 차이   |
 | ------------------------------------------ | ---------------------------------------------------------------- | ------------------------------------------------------------ | ------ |
-| Unpacked Size                              | [219 kB](https://www.npmjs.com/package/react-simplikit)          | [454 kB](https://www.npmjs.com/package/react-use)            | -51.7% |
-| Minified Size                              | [8.7 kB](https://bundlephobia.com/package/react-simplikit@0.0.7) | [78.2 kB](https://bundlephobia.com/package/react-use@17.6.0) | -88.8% |
-| Gzipped Size                               | [2.9 kB](https://bundlephobia.com/package/react-simplikit@0.0.7) | [22 kB](https://bundlephobia.com/package/react-use@17.6.0)   | -86.8% |
-| 평균 함수 당 크기<br/>(Minified Size 기준) | 348 byte                                                         | 680 byte                                                     | -48.8% |
+| Unpacked Size                              | [237 kB](https://www.npmjs.com/package/react-simplikit)          | [454 kB](https://www.npmjs.com/package/react-use)            | -47.8% |
+| Minified Size                              | [8.7 kB](https://bundlephobia.com/package/react-simplikit@0.0.29) | [78.2 kB](https://bundlephobia.com/package/react-use@17.6.0) | -88.9% |
+| Gzipped Size                               | [2.9 kB](https://bundlephobia.com/package/react-simplikit@0.0.29) | [22 kB](https://bundlephobia.com/package/react-use@17.6.0)   | -86.9% |
+| 평균 함수 당 크기<br/>(Minified Size 기준) | 318.2 byte                                                         | 696.3 byte                                                     | -54.3% |


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

- update invalid links
- update to the correct bundle size

## note

- set `react-use` to have [115 functions](https://www.npmjs.com/package/react-use) in it.
- set `react-simplikit` to have 28 functions. (see sidebar in the [documentation](https://react-simplikit.slash.page/))

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
