### PR TITLE
style: update background colors of codeblocks

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -211,3 +211,13 @@
   font-size: 14px;
   color: var(--vp-color-secondary);
 }
+
+div.codeblock {
+  padding: 20px 24px;
+  border-radius: 8px;
+  background-color: white;
+}
+
+html.dark div.codeblock {
+  background-color: var(--vp-c-bg-alt);
+}

--- a/src/docs/en/contributing.md
+++ b/src/docs/en/contributing.md
@@ -66,7 +66,7 @@ JSDoc comments must include `@description` and `@example`, and if there are para
 
     This JSDoc will be converted into the following documentation.
 
-    <div style="background: white; padding: 20px 24px; border-radius: 8px;">
+    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
       <Interface
         required
         name="name"
@@ -140,7 +140,7 @@ JSDoc comments must include `@description` and `@example`, and if there are para
 
     This JSDoc will be converted into the following documentation.
 
-    <div style="background: white; padding: 20px 24px; border-radius: 8px;">
+    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
       <Interface
         name=""
         type="[value: string, onChange: () => void]"
@@ -176,7 +176,7 @@ JSDoc comments must include `@description` and `@example`, and if there are para
 
     This JSDoc will be converted into the following documentation.
 
-    <div style="background: white; padding: 20px 24px; border-radius: 8px;">
+    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
       <Interface
         name=""
         type="Object"
@@ -271,7 +271,7 @@ All `react-simplikit` implementations use special rendering functions to verify 
 
 ### Deployment
 
-When changes are merged into the main branch, deployment happens automatically. You can view the deployment results in [GitHub Actions](https://github.com/toss/react-simplikit/actions).
+When changes are merged into the `main` branch, deployment happens automatically. You can view the deployment results in [GitHub Actions](https://github.com/toss/react-simplikit/actions).
 
 ## Documentation Contribution
 

--- a/src/docs/en/contributing.md
+++ b/src/docs/en/contributing.md
@@ -66,7 +66,7 @@ JSDoc comments must include `@description` and `@example`, and if there are para
 
     This JSDoc will be converted into the following documentation.
 
-    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
+    <div class='codeblock'>
       <Interface
         required
         name="name"
@@ -140,7 +140,7 @@ JSDoc comments must include `@description` and `@example`, and if there are para
 
     This JSDoc will be converted into the following documentation.
 
-    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
+    <div class='codeblock'>
       <Interface
         name=""
         type="[value: string, onChange: () => void]"
@@ -176,7 +176,7 @@ JSDoc comments must include `@description` and `@example`, and if there are para
 
     This JSDoc will be converted into the following documentation.
 
-    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
+    <div class='codeblock'>
       <Interface
         name=""
         type="Object"

--- a/src/docs/ko/contributing.md
+++ b/src/docs/ko/contributing.md
@@ -66,7 +66,7 @@ JSDoc 주석은 `@description`과 `@example`을 반드시 포함해야 하고, �
 
     이 파라미터 JSDoc은 다음과 같은 문서로 변환돼요.
 
-    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
+    <div class='codeblock'>
       <Interface
         required
         name="name"
@@ -140,7 +140,7 @@ JSDoc 주석은 `@description`과 `@example`을 반드시 포함해야 하고, �
 
     이 반환 값 JSDoc은 다음과 같은 문서로 변환돼요.
 
-    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
+    <div class='codeblock'>
       <Interface
         name=""
         type="[value: string, onChange: () => void]"
@@ -176,7 +176,7 @@ JSDoc 주석은 `@description`과 `@example`을 반드시 포함해야 하고, �
 
     이 반환 값 JSDoc은 다음과 같은 문서로 변환돼요.
 
-    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
+    <div class='codeblock'>
       <Interface
         name=""
         type="Object"

--- a/src/docs/ko/contributing.md
+++ b/src/docs/ko/contributing.md
@@ -66,7 +66,7 @@ JSDoc 주석은 `@description`과 `@example`을 반드시 포함해야 하고, �
 
     이 파라미터 JSDoc은 다음과 같은 문서로 변환돼요.
 
-    <div style="background: white; padding: 20px 24px; border-radius: 8px;">
+    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
       <Interface
         required
         name="name"
@@ -140,7 +140,7 @@ JSDoc 주석은 `@description`과 `@example`을 반드시 포함해야 하고, �
 
     이 반환 값 JSDoc은 다음과 같은 문서로 변환돼요.
 
-    <div style="background: white; padding: 20px 24px; border-radius: 8px;">
+    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
       <Interface
         name=""
         type="[value: string, onChange: () => void]"
@@ -176,7 +176,7 @@ JSDoc 주석은 `@description`과 `@example`을 반드시 포함해야 하고, �
 
     이 반환 값 JSDoc은 다음과 같은 문서로 변환돼요.
 
-    <div style="background: white; padding: 20px 24px; border-radius: 8px;">
+    <div style="background: #161618; padding: 20px 24px; border-radius: 8px;">
       <Interface
         name=""
         type="Object"


### PR DESCRIPTION
# Overview

- update the background color of codeblocks to improve readability.
- add missing inline code.

### codeblock background

#### before

<img width="586" alt="스크린샷 2025-04-19 오후 4 17 41" src="https://github.com/user-attachments/assets/e8e00a61-bb4e-4c8f-aaab-c99b976686dd" />

#### after

<img width="496" alt="스크린샷 2025-04-19 오후 4 21 30" src="https://github.com/user-attachments/assets/8909f383-a8a1-495c-a533-7b717b557a73" />

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
