### PR TITLE
docs(SwitchCase): add 'boolean' type

### DIFF
--- a/src/components/SwitchCase/SwitchCase.md
+++ b/src/components/SwitchCase/SwitchCase.md
@@ -6,8 +6,8 @@
 
 ```ts
 function SwitchCase(
-  value: string | number,
-  caseBy: Record<string | number, () => JSX.Element>,
+  value: string | number | boolean,
+  caseBy: Record<string | number | boolean, () => JSX.Element>,
   defaultComponent: () => JSX.Element
 ): JSX.Element;
 ```
@@ -17,14 +17,14 @@ function SwitchCase(
 <Interface
   required
   name="value"
-  type="string | number"
+  type="string | number | boolean"
   description="The value to compare against. The component associated with the matching key in <code>caseBy</code> will be rendered."
 />
 
 <Interface
   required
   name="caseBy"
-  type="Record<string | number, () => JSX.Element>"
+  type="Record<string | number | boolean, () => JSX.Element>"
   description="An object that maps values to components to render. The keys represent possible values, and the values are functions returning the corresponding components."
 />
 

--- a/src/components/SwitchCase/SwitchCase.tsx
+++ b/src/components/SwitchCase/SwitchCase.tsx
@@ -17,9 +17,9 @@ type Props<Case> = {
  * similar to a `switch-case` statement. It is useful when you need to conditionally render different
  * components depending on a specific state.
  *
- * @param {string | number} value - The value to compare against.
+ * @param {string | number | boolean} value - The value to compare against.
  *   The component associated with the matching key in `caseBy` will be rendered.
- * @param {Record<string | number, () => JSX.Element>} caseBy - An object that maps values to
+ * @param {Record<string | number | boolean, () => JSX.Element>} caseBy - An object that maps values to
  *   components to render. The keys represent possible values, and the values are functions returning
  *   the corresponding components.
  * @param {() => JSX.Element} [defaultComponent] - The component to render if `value` does not match

--- a/src/components/SwitchCase/SwitchCase.tsx
+++ b/src/components/SwitchCase/SwitchCase.tsx
@@ -17,15 +17,15 @@ type Props<Case> = {
  * similar to a `switch-case` statement. It is useful when you need to conditionally render different
  * components depending on a specific state.
  *
- * @param {string | number | boolean} value - The value to compare against.
+ * @param {Case} value - The value to compare against.
  *   The component associated with the matching key in `caseBy` will be rendered.
- * @param {Record<string | number | boolean, () => JSX.Element>} caseBy - An object that maps values to
+ * @param {Partial<{ [P in StringifiedValue<Case>]: () => ReactElement | null }>} caseBy - An object that maps values to
  *   components to render. The keys represent possible values, and the values are functions returning
  *   the corresponding components.
- * @param {() => JSX.Element} [defaultComponent] - The component to render if `value` does not match
+ * @param {() => ReactElement | null} [defaultComponent] - The component to render if `value` does not match
  *   any key in `caseBy`.
  *
- * @returns {JSX.Element} A React component that conditionally renders based on cases.
+ * @returns {ReactElement | null} A React component that conditionally renders based on cases.
  *
  * @example
  * function App() {

--- a/src/components/SwitchCase/ko/SwitchCase.md
+++ b/src/components/SwitchCase/ko/SwitchCase.md
@@ -6,8 +6,8 @@
 
 ```ts
 function SwitchCase(
-  value: string | number,
-  caseBy: Record<string | number, () => JSX.Element>,
+  value: string | number | boolean,
+  caseBy: Record<string | number | boolean, () => JSX.Element>,
   defaultComponent: () => JSX.Element
 ): JSX.Element;
 ```
@@ -17,14 +17,14 @@ function SwitchCase(
 <Interface
   required
   name="value"
-  type="string | number"
+  type="string | number | boolean"
   description="비교할 값이에요. <code>caseBy</code>에서 일치하는 키와 연결된 컴포넌트가 렌더링돼요."
 />
 
 <Interface
   required
   name="caseBy"
-  type="Record<string | number, () => JSX.Element>"
+  type="Record<string | number | boolean, () => JSX.Element>"
   description="렌더링할 컴포넌트를 값으로 맵핑하는 객체예요. 키는 가능한 값을 나타내며, 값은 해당 컴포넌트를 반환하는 함수예요."
 />
 


### PR DESCRIPTION
# Overview

SwitchCase 의 value에 boolean이 실제로 사용 가능한데 문서와 타입 정의에는 빠져있어서 추가했습니다.

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
