### PR TITLE
docs(useVisibilityEvent): Replace literal union type with DocumentVisibilityState

### DIFF
--- a/src/hooks/useVisibilityEvent/ko/useVisibilityEvent.md
+++ b/src/hooks/useVisibilityEvent/ko/useVisibilityEvent.md
@@ -6,7 +6,7 @@
 
 ```ts
 function useVisibilityEvent(
-  callback: (visibilityState: 'visible' | 'hidden') => void,
+  callback: (visibilityState: DocumentVisibilityState) => void,
   options: object
 ): void;
 ```
@@ -16,7 +16,7 @@ function useVisibilityEvent(
 <Interface
   required
   name="callback"
-  type="(visibilityState: 'visible' | 'hidden') => void"
+  type="(visibilityState: DocumentVisibilityState) => void"
   description="가시성 상태가 변할 때 호출되는 함수예요. 현재 가시성 상태('visible' 또는 'hidden')를 인자로 받아요."
 />
 

--- a/src/hooks/useVisibilityEvent/useVisibilityEvent.md
+++ b/src/hooks/useVisibilityEvent/useVisibilityEvent.md
@@ -6,7 +6,7 @@ A React hook that listens to changes in the document's visibility state and trig
 
 ```ts
 function useVisibilityEvent(
-  callback: (visibilityState: 'visible' | 'hidden') => void,
+  callback: (visibilityState: DocumentVisibilityState) => void,
   options: object
 ): void;
 ```
@@ -16,7 +16,7 @@ function useVisibilityEvent(
 <Interface
   required
   name="callback"
-  type="(visibilityState: 'visible' | 'hidden') => void"
+  type="(visibilityState: DocumentVisibilityState) => void"
   description="A function to be called when the visibility state changes. It receives the current visibility state ('visible' or 'hidden') as an argument."
 />
 

--- a/src/hooks/useVisibilityEvent/useVisibilityEvent.ts
+++ b/src/hooks/useVisibilityEvent/useVisibilityEvent.ts
@@ -8,7 +8,7 @@ type Options = {
  * @description
  * A React hook that listens to changes in the document's visibility state and triggers a callback.
  *
- * @param {(visibilityState: 'visible' | 'hidden') => void} callback - A function to be called
+ * @param {(visibilityState: DocumentVisibilityState) => void} callback - A function to be called
  * when the visibility state changes. It receives the current visibility state ('visible' or 'hidden') as an argument.
  * @param {object} [options] - Optional configuration for the hook.
  * @param {boolean} [options.immediate=false] - If true, the callback is invoked immediately upon mounting
@@ -26,7 +26,10 @@ type Options = {
  * }
  */
 
-export function useVisibilityEvent(callback: (visibilityState: 'visible' | 'hidden') => void, options: Options = {}) {
+export function useVisibilityEvent(
+  callback: (visibilityState: DocumentVisibilityState) => void,
+  options: Options = {}
+) {
   const handleVisibilityChange = useCallback(() => {
     callback(document.visibilityState);
   }, [callback]);


### PR DESCRIPTION
# Overview
<!-- A clear and concise description of what this PR is about. -->

This PR replaces the manually defined literal union type 'visible' | 'hidden' with the built-in DocumentVisibilityState type provided by the DOM API.

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
