### PR TITLE
docs: fix mergeProps documentation to match actual implementation

### DIFF
--- a/src/utils/mergeProps/ko/mergeProps.md
+++ b/src/utils/mergeProps/ko/mergeProps.md
@@ -6,7 +6,7 @@
 
 ```ts
 function mergeProps<PropsList>(
-  props: PropsList
+  ...props: PropsList
 ): TupleToIntersection<PropsList>;
 ```
 

--- a/src/utils/mergeProps/mergeProps.md
+++ b/src/utils/mergeProps/mergeProps.md
@@ -6,7 +6,7 @@
 
 ```ts
 function mergeProps<PropsList>(
-  props: PropsList
+  ...props: PropsList
 ): TupleToIntersection<PropsList>;
 ```
 


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

This pull request corrects the `mergeProps`' documentation where the variadic argument is represented as `props` instead of `...props`.

Current `mergeProps` function's implementation:

https://github.com/toss/react-simplikit/blob/94f8826353479d34aeba5f1479a2b831eb645ff7/src/utils/mergeProps/mergeProps.ts#L28

But current `mergeProps` documentation doesn't let readers know `props` argument is variable:

https://github.com/toss/react-simplikit/blob/94f8826353479d34aeba5f1479a2b831eb645ff7/src/utils/mergeProps/mergeProps.md?plain=1#L7-L11

So this pull request changes the above lines like following lines:

https://github.com/toss/react-simplikit/blob/ce3b5abe7486f088a349341f1ff8663a4594e12d/src/utils/mergeProps/ko/mergeProps.md?plain=1#L7-L11

## Checklist

- [ ] Did you write the test code?
  - This pull request doesn't make changes about implementations and types.
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
  - This pull request doesn't make changes about implementations and types.