### PR TITLE
feat(hooks): add 'useEventListener' hook

### DIFF
--- a/src/hooks/useEventListener/index.ts
+++ b/src/hooks/useEventListener/index.ts
@@ -1,0 +1,1 @@
+export { useEventListener } from './useEventListener.ts';

--- a/src/hooks/useEventListener/ko/useEventListener.md
+++ b/src/hooks/useEventListener/ko/useEventListener.md
@@ -1,0 +1,59 @@
+# useEventListener
+
+useEventListener는 특정 DOM 요소에 이벤트 리스너를 등록하는 React 훅이에요. 타입 안정성을 갖추고 편리한 방식으로 이벤트 리스너를 관리할 수 있도록 도와주며, 자동 클린업 및 안정적인 콜백 참조를 제공해요.
+
+## 인터페이스
+
+```ts
+function useEventListener<
+  K extends keyof HTMLElementEventMap,
+  T extends HTMLElement = any,
+>(
+  type: K,
+  listener: (event: HTMLElementEventMap[K]) => any,
+  options?: AddEventListenerOptions
+): Ref<T>;
+```
+
+### 파라미터
+
+<Interface
+  required
+  name="type"
+  type="K"
+  description="이벤트 타입이에요 (예: 'click', 'keydown')."
+/>
+
+<Interface
+  required
+  name="listener"
+  type="(event: HTMLElementEventMap[K]) => any"
+  description="이벤트가 발생했을 때 호출될 콜백 함수예요."
+/>
+
+<Interface
+  name="options"
+  type="AddEventListenerOptions"
+  description="이벤트 리스너의 선택적 옵션 객체예요 (예: capture, once, passive)."
+/>
+
+### 반환 값
+
+<Interface
+  name=""
+  type="Ref<T>"
+  description="대상 DOM 요소에 할당해야 하는 React ref 객체예요."
+/>
+
+## 예시
+
+```tsx
+function LoggerButton() {
+  const [count, setCount] = useState(0);
+  const buttonRef = useEventListener('click', () => {
+    setCount(prev => prev + 1);
+  });
+
+  return <button ref={buttonRef}>{count}</button>;
+}
+```

--- a/src/hooks/useEventListener/useEventListener.md
+++ b/src/hooks/useEventListener/useEventListener.md
@@ -1,0 +1,59 @@
+# useEventListener
+
+`useEventListener` is a React hook that attaches an event listener to a DOM element. It helps manage DOM event listeners in a clean, type-safe way with automatic cleanup and stable callback references.
+
+## Interface
+
+```ts
+function useEventListener<
+  K extends keyof HTMLElementEventMap,
+  T extends HTMLElement = any,
+>(
+  type: K,
+  listener: (event: HTMLElementEventMap[K]) => any,
+  options?: AddEventListenerOptions
+): Ref<T>;
+```
+
+### Parameters
+
+<Interface
+  required
+  name="type"
+  type="K"
+  description="The event type to listen for (e.g., 'click', 'keydown')."
+/>
+
+<Interface
+  required
+  name="listener"
+  type="(event: HTMLElementEventMap[K]) => any"
+  description="The callback function to be called when the event occurs."
+/>
+
+<Interface
+  name="options"
+  type="AddEventListenerOptions"
+  description="Optional options object for the event listener (e.g., capture, once, passive)."
+/>
+
+### Return Value
+
+<Interface
+  name=""
+  type="Ref<T>"
+  description="A React ref object that should be assigned to the target DOM element."
+/>
+
+## Example
+
+```tsx
+function LoggerButton() {
+  const [count, setCount] = useState(0);
+  const buttonRef = useEventListener('click', () => {
+    setCount(prev => prev + 1);
+  });
+
+  return <button ref={buttonRef}>{count}</button>;
+}
+```

--- a/src/hooks/useEventListener/useEventListener.spec.tsx
+++ b/src/hooks/useEventListener/useEventListener.spec.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useEventListener } from './useEventListener.ts';
+
+describe('useEventListener', () => {
+  it('should add event listener to the element', () => {
+    const fn = vi.fn();
+
+    const TestComponent = () => {
+      const ref = useEventListener('click', fn);
+      return <button ref={ref}>Button</button>;
+    };
+
+    render(<TestComponent />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useEventListener/useEventListener.ts
+++ b/src/hooks/useEventListener/useEventListener.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Ref, useEffect, useRef } from 'react';
+
+import { usePreservedCallback } from '../usePreservedCallback/usePreservedCallback.ts';
+
+/**
+ * @description
+ * `useEventListener` is a React hook that attaches an event listener to a DOM element.
+ * It helps manage DOM event listeners in a clean, type-safe way with automatic cleanup and stable callback references.
+ *
+ * @param {K} type - The event type to listen for (e.g., 'click', 'keydown').
+ * @param {(event: HTMLElementEventMap[K]) => any} listener - The callback function to be called when the event occurs.
+ * @param {AddEventListenerOptions} [options] - Optional options object for the event listener (e.g., capture, once, passive).
+ *
+ * @returns {Ref<T>} A React ref object that should be assigned to the target DOM element.
+ *
+ * @example
+ * function LoggerButton() {
+ *   const [count, setCount] = useState(0);
+ *   const buttonRef = useEventListener('click', () => {
+ *     setCount(prev => prev + 1);
+ *   });
+ *
+ *   return (
+ *     <button ref={buttonRef}>{count}</button>
+ *   );
+ * }
+ */
+
+export const useEventListener = <K extends keyof HTMLElementEventMap, T extends HTMLElement = any>(
+  type: K,
+  listener: (event: HTMLElementEventMap[K]) => any,
+  options?: AddEventListenerOptions
+): Ref<T> => {
+  const ref = useRef<T>(null);
+  const preservedListener = usePreservedCallback(listener);
+
+  useEffect(() => {
+    const node = ref.current;
+
+    if (node) {
+      node.addEventListener(type, preservedListener, options);
+    }
+    return () => {
+      node?.removeEventListener(type, preservedListener, options);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preservedListener, options]);
+
+  return ref;
+};


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

Add useEventListener hook that enables clean and declarative attachment of event listeners to DOM elements using refs.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
