### PR TITLE
feat(useGeolocation): add useGeolocation hook

### DIFF
--- a/src/hooks/useGeolocation/index.ts
+++ b/src/hooks/useGeolocation/index.ts
@@ -1,0 +1,1 @@
+export { useGeolocation } from './useGeolocation.ts';

--- a/src/hooks/useGeolocation/useGeolocation.spec.ts
+++ b/src/hooks/useGeolocation/useGeolocation.spec.ts
@@ -1,0 +1,311 @@
+import { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderHookSSR } from '../../_internal/test-utils/renderHookSSR.tsx';
+
+import { CustomGeoLocationError, useGeolocation } from './useGeolocation.ts';
+
+const mockGeolocation = {
+  getCurrentPosition: vi.fn(),
+  watchPosition: vi.fn(),
+  clearWatch: vi.fn(),
+};
+
+const mockPosition = {
+  coords: {
+    latitude: 37.5326,
+    longitude: 127.0246,
+    accuracy: 10,
+    altitude: 100,
+    altitudeAccuracy: 10,
+    heading: 90,
+    speed: 5,
+  },
+  timestamp: Date.now(),
+} as GeolocationPosition;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  Object.defineProperty(global.navigator, 'geolocation', {
+    value: mockGeolocation,
+    writable: true,
+  });
+});
+
+describe('useGeolocation', () => {
+  it('should retrieve location data when getCurrentPosition is called', async () => {
+    let successCallback: PositionCallback;
+
+    mockGeolocation.getCurrentPosition.mockImplementation(success => {
+      successCallback = success;
+    });
+
+    const { result } = renderHookSSR(() => useGeolocation());
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+
+    act(() => {
+      result.current.getCurrentPosition();
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    act(() => {
+      successCallback(mockPosition);
+    });
+
+    expect(result.current.data).toEqual({
+      latitude: mockPosition.coords.latitude,
+      longitude: mockPosition.coords.longitude,
+      accuracy: mockPosition.coords.accuracy,
+      altitude: mockPosition.coords.altitude,
+      altitudeAccuracy: mockPosition.coords.altitudeAccuracy,
+      heading: mockPosition.coords.heading,
+      speed: mockPosition.coords.speed,
+      timestamp: mockPosition.timestamp,
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should return appropriate error and terminate function calls when used in unsupported environments', () => {
+    Object.defineProperty(global.navigator, 'geolocation', { value: undefined });
+
+    const { result } = renderHookSSR(() => useGeolocation({ mountBehavior: 'get' }));
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+
+    const customError = result.current.error as CustomGeoLocationError;
+
+    expect(customError.code).toBe(0);
+    expect(customError.message).toBe('Geolocation is not supported by this environment.');
+    expect(customError.name).toBe('CustomGeoLocationError');
+
+    vi.clearAllMocks();
+
+    act(() => {
+      result.current.startTracking();
+    });
+
+    expect(mockGeolocation.watchPosition).not.toHaveBeenCalled();
+    expect(result.current.error?.code).toBe(0);
+    expect(result.current.error?.message).toBe('Geolocation is not supported by this environment.');
+    expect(customError.name).toBe('CustomGeoLocationError');
+
+    act(() => {
+      result.current.stopTracking();
+    });
+
+    expect(mockGeolocation.clearWatch).not.toHaveBeenCalled();
+  });
+
+  it('should update error state when getCurrentPosition call fails', async () => {
+    const mockPositionError = {
+      code: 1,
+      message: 'User denied Geolocation',
+    };
+
+    mockGeolocation.getCurrentPosition.mockImplementation((success, error) => {
+      error(mockPositionError);
+    });
+
+    const { result } = renderHookSSR(() => useGeolocation());
+
+    act(() => {
+      result.current.getCurrentPosition();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+
+    const customError = result.current.error as CustomGeoLocationError;
+
+    expect(customError.code).toBe(1);
+    expect(customError.message).toBe('User denied Geolocation');
+    expect(customError.name).toBe('CustomGeoLocationError');
+  });
+
+  it('should automatically call getCurrentPosition on mount when mountBehavior option is "get"', () => {
+    mockGeolocation.getCurrentPosition.mockImplementation(() => {});
+
+    const { result } = renderHookSSR(() => useGeolocation({ mountBehavior: 'get' }));
+
+    expect(result.current.loading).toBe(true);
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({})
+    );
+  });
+
+  it('should automatically call startTracking on mount when mountBehavior is "watch"', () => {
+    mockGeolocation.watchPosition.mockImplementation(() => {});
+
+    const { result } = renderHookSSR(() => useGeolocation({ mountBehavior: 'watch' }));
+
+    expect(result.current.loading).toBe(true);
+    expect(mockGeolocation.watchPosition).toHaveBeenCalledTimes(1);
+    expect(mockGeolocation.watchPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({})
+    );
+  });
+
+  it('should not automatically request location when mountBehavior option is not provided', () => {
+    const { result } = renderHookSSR(() => useGeolocation());
+
+    expect(result.current.loading).toBe(false);
+    expect(mockGeolocation.getCurrentPosition).not.toHaveBeenCalled();
+    expect(mockGeolocation.watchPosition).not.toHaveBeenCalled();
+  });
+
+  it('should correctly pass geolocation options', () => {
+    const options = {
+      mountBehavior: 'get' as const,
+      enableHighAccuracy: true,
+      maximumAge: 1000,
+      timeout: 5000,
+    };
+
+    renderHookSSR(() => useGeolocation(options));
+
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({
+        enableHighAccuracy: true,
+        maximumAge: 1000,
+        timeout: 5000,
+      })
+    );
+  });
+
+  it('should return updated location data when position changes during tracking', async () => {
+    const updatedPosition = {
+      coords: {
+        latitude: 37.5665,
+        longitude: 126.978,
+        accuracy: 15,
+        altitude: 120,
+        altitudeAccuracy: 15,
+        heading: 180,
+        speed: 10,
+      },
+      timestamp: Date.now() + 1000,
+    } as GeolocationPosition;
+
+    let watchCallback: PositionCallback;
+    mockGeolocation.watchPosition.mockImplementation(success => {
+      watchCallback = success;
+      return 123;
+    });
+
+    const { result } = renderHookSSR(() => useGeolocation());
+
+    act(() => {
+      result.current.startTracking();
+    });
+
+    act(() => {
+      watchCallback(mockPosition);
+    });
+
+    expect(result.current.data).toEqual({
+      latitude: mockPosition.coords.latitude,
+      longitude: mockPosition.coords.longitude,
+      accuracy: mockPosition.coords.accuracy,
+      altitude: mockPosition.coords.altitude,
+      altitudeAccuracy: mockPosition.coords.altitudeAccuracy,
+      heading: mockPosition.coords.heading,
+      speed: mockPosition.coords.speed,
+      timestamp: mockPosition.timestamp,
+    });
+
+    act(() => {
+      watchCallback(updatedPosition);
+    });
+
+    expect(result.current.data).toEqual({
+      latitude: updatedPosition.coords.latitude,
+      longitude: updatedPosition.coords.longitude,
+      accuracy: updatedPosition.coords.accuracy,
+      altitude: updatedPosition.coords.altitude,
+      altitudeAccuracy: updatedPosition.coords.altitudeAccuracy,
+      heading: updatedPosition.coords.heading,
+      speed: updatedPosition.coords.speed,
+      timestamp: updatedPosition.timestamp,
+    });
+  });
+
+  it('should call clearWatch if watchId already exists when startTracking is called', () => {
+    mockGeolocation.watchPosition.mockReturnValue(123);
+
+    const { result } = renderHookSSR(() => useGeolocation());
+
+    act(() => {
+      result.current.startTracking();
+    });
+
+    expect(mockGeolocation.clearWatch).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.startTracking();
+    });
+
+    expect(mockGeolocation.clearWatch).toHaveBeenCalledWith(123);
+  });
+
+  it('should properly update isTracking state when starting and stopping location tracking', () => {
+    let watchPositionCallback: PositionCallback;
+
+    mockGeolocation.watchPosition.mockImplementation(success => {
+      watchPositionCallback = success;
+
+      return 123;
+    });
+
+    const { result } = renderHookSSR(() => useGeolocation());
+
+    expect(result.current.isTracking).toBe(false);
+
+    act(() => {
+      result.current.startTracking();
+    });
+
+    act(() => {
+      watchPositionCallback(mockPosition);
+    });
+
+    expect(result.current.isTracking).toBe(true);
+    expect(mockGeolocation.watchPosition).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.stopTracking();
+    });
+
+    expect(result.current.isTracking).toBe(false);
+    expect(mockGeolocation.clearWatch).toHaveBeenCalledWith(123);
+  });
+
+  it('should clean up watchPosition when component unmounts', () => {
+    mockGeolocation.watchPosition.mockReturnValue(123);
+
+    const { result, unmount } = renderHookSSR(() => useGeolocation());
+
+    act(() => {
+      result.current.startTracking();
+    });
+
+    unmount();
+
+    expect(mockGeolocation.clearWatch).toHaveBeenCalledWith(123);
+  });
+});

--- a/src/hooks/useGeolocation/useGeolocation.ts
+++ b/src/hooks/useGeolocation/useGeolocation.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export class CustomGeoLocationError extends Error {
+  code: number;
+
+  constructor({ code, message }: { message: string; code: number }) {
+    super(message);
+    this.name = 'CustomGeoLocationError';
+    this.code = code;
+  }
+}
+
+type GeolocationData = {
+  latitude: number;
+  longitude: number;
+  accuracy: number;
+  altitude: number | null;
+  altitudeAccuracy: number | null;
+  heading: number | null;
+  speed: number | null;
+  timestamp: number | null;
+};
+
+const GeolocationMountBehavior = {
+  GET: 'get',
+  WATCH: 'watch',
+} as const;
+
+type GeolocationMountBehaviorType = (typeof GeolocationMountBehavior)[keyof typeof GeolocationMountBehavior];
+
+type GeolocationOptions = {
+  mountBehavior?: GeolocationMountBehaviorType;
+} & PositionOptions;
+
+/**
+ * @description
+ * A React custom hook that retrieves and tracks the user's geographical location.
+ * It supports both one-time position retrieval and continuous location tracking.
+ *
+ * @param {GeolocationOptions} [options] - Geolocation options configuration
+ * @param {GeolocationMountBehaviorType} [options.mountBehavior] - How the hook behaves on mount:
+ *   - If not provided, no automatic location fetching occurs
+ *   - 'get': automatically fetches location once when component mounts
+ *   - 'watch': automatically starts tracking location changes when component mounts
+ * @param {boolean} [options.enableHighAccuracy=false] - If true, provides more accurate position information (increases battery consumption)
+ * @param {number} [options.maximumAge=0] - Maximum age in milliseconds of a cached position that is acceptable to return
+ * @param {number} [options.timeout=Infinity] - Maximum time (in milliseconds) allowed for the location request
+ *
+ * @returns {Object} Object containing location data and related functions
+ * - `loading` {boolean} - Whether location data is currently being fetched
+ * - `error` {CustomGeoLocationError|null} - Error object if an error occurred, or null.
+ *   The hook uses standard Geolocation API error codes (1-3) and adds a custom code (0):
+ *   - 0: Geolocation is not supported by the environment
+ *   - 1: User denied permission to access geolocation
+ *   - 2: Position unavailable
+ *   - 3: Timeout - geolocation request took too long
+ * - `data` {GeolocationData|null} - Location data object or null
+ * - `getCurrentPosition` {Function} - Function to get the current position once
+ * - `startTracking` {Function} - Function to start tracking location changes
+ * - `stopTracking` {Function} - Function to stop tracking location
+ * - `isTracking` {boolean} - Whether location tracking is currently active
+ *
+ * @example
+ * // Basic usage
+ * const {
+ *   loading,
+ *   error,
+ *   data,
+ *   getCurrentPosition
+ * } = useGeolocation();
+ *
+ * // Automatically fetch location when component mounts
+ * const {
+ *   loading,
+ *   error,
+ *   data
+ * } = useGeolocation({ mountBehavior: 'get' });
+ *
+ * // Location tracking
+ * const {
+ *   loading,
+ *   error,
+ *   data,
+ *   startTracking,
+ *   stopTracking,
+ *   isTracking
+ * } = useGeolocation();
+ *
+ * const handleStartTracking = () => {
+ *   startTracking();
+ * };
+ *
+ * const handleStopTracking = () => {
+ *   stopTracking();
+ * };
+ */
+export function useGeolocation(options?: GeolocationOptions) {
+  const [state, setState] = useState<{
+    loading: boolean;
+    error: CustomGeoLocationError | null;
+    data: GeolocationData | null;
+  }>({
+    loading: !!options?.mountBehavior,
+    error: null,
+    data: null,
+  });
+  const [isTracking, setIsTracking] = useState(false);
+
+  const watchIdRef = useRef<number | null>(null);
+
+  const checkGeolocationSupport = useCallback(() => {
+    if (typeof window === 'undefined' || navigator.geolocation === undefined) {
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        error: new CustomGeoLocationError({
+          code: 0,
+          message: 'Geolocation is not supported by this environment.',
+        }),
+      }));
+
+      return false;
+    }
+
+    return true;
+  }, []);
+
+  const handleSuccess = useCallback((position: GeolocationPosition) => {
+    const { coords } = position;
+
+    setState(prev => ({
+      ...prev,
+      loading: false,
+      error: null,
+      data: {
+        latitude: coords.latitude,
+        longitude: coords.longitude,
+        accuracy: coords.accuracy,
+        altitude: coords.altitude,
+        altitudeAccuracy: coords.altitudeAccuracy,
+        heading: coords.heading,
+        speed: coords.speed,
+        timestamp: position.timestamp,
+      },
+    }));
+  }, []);
+
+  const handleError = useCallback((error: GeolocationPositionError) => {
+    const { code, message } = error;
+    setState(prev => ({
+      ...prev,
+      loading: false,
+      error: new CustomGeoLocationError({ code, message }),
+    }));
+  }, []);
+
+  const getGeolocationOptions = useCallback(
+    () => ({
+      enableHighAccuracy: options?.enableHighAccuracy,
+      maximumAge: options?.maximumAge,
+      timeout: options?.timeout,
+    }),
+    [options?.enableHighAccuracy, options?.maximumAge, options?.timeout]
+  );
+
+  const getCurrentPosition = useCallback(() => {
+    if (!checkGeolocationSupport()) {
+      return;
+    }
+
+    setState(prev => ({ ...prev, loading: true }));
+
+    navigator.geolocation.getCurrentPosition(handleSuccess, handleError, getGeolocationOptions());
+  }, [handleSuccess, handleError, getGeolocationOptions, checkGeolocationSupport]);
+
+  const startTracking = useCallback(() => {
+    if (!checkGeolocationSupport()) {
+      return;
+    }
+
+    if (watchIdRef.current !== null) {
+      navigator.geolocation.clearWatch(watchIdRef.current);
+    }
+
+    setState(prev => ({ ...prev, loading: true }));
+
+    watchIdRef.current = navigator.geolocation.watchPosition(
+      position => {
+        setIsTracking(true);
+        handleSuccess(position);
+      },
+      handleError,
+      getGeolocationOptions()
+    );
+  }, [handleSuccess, handleError, getGeolocationOptions, checkGeolocationSupport]);
+
+  const stopTracking = useCallback(() => {
+    if (watchIdRef.current === null) {
+      return;
+    }
+
+    navigator.geolocation.clearWatch(watchIdRef.current);
+    watchIdRef.current = null;
+    setIsTracking(false);
+  }, []);
+
+  useEffect(() => {
+    if (options?.mountBehavior === GeolocationMountBehavior.WATCH) {
+      startTracking();
+    } else if (options?.mountBehavior === GeolocationMountBehavior.GET) {
+      getCurrentPosition();
+    }
+
+    return () => {
+      if (watchIdRef.current !== null) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+        watchIdRef.current = null;
+      }
+    };
+  }, [options?.mountBehavior, getCurrentPosition, startTracking]);
+
+  return {
+    ...state,
+    getCurrentPosition,
+    startTracking,
+    stopTracking,
+    isTracking,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { useCounter } from './hooks/useCounter/index.ts';
 export { useDebounce } from './hooks/useDebounce/index.ts';
 export { useDebouncedCallback } from './hooks/useDebouncedCallback/index.ts';
 export { useDoubleClick } from './hooks/useDoubleClick/index.ts';
+export { useGeolocation } from './hooks/useGeolocation/index.ts';
 export { useImpressionRef } from './hooks/useImpressionRef/index.ts';
 export { useInputState } from './hooks/useInputState/index.ts';
 export { useIntersectionObserver } from './hooks/useIntersectionObserver/index.ts';


### PR DESCRIPTION
# Overview

A new `useGeolocation` hook that wraps the browser's `Geolocation API`. Provides a simple interface for accessing and tracking the user's location.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
