### PR TITLE
fix: Apply forwardRef to ImpressionArea

### DIFF
--- a/src/components/ImpressionArea/ImpressionArea.tsx
+++ b/src/components/ImpressionArea/ImpressionArea.tsx
@@ -1,4 +1,4 @@
-import { ElementType, ReactNode, Ref } from 'react';
+import { ElementType, forwardRef, ReactNode, Ref } from 'react';
 
 import { useImpressionRef, UseImpressionRefOptions } from '../../hooks/useImpressionRef/index.ts';
 import { mergeRefs } from '../../utils/mergeRefs/mergeRefs.ts';
@@ -43,24 +43,22 @@ type Props<Tag extends ElementType> = React.ComponentPropsWithoutRef<Tag> &
  *   );
  * }
  */
-export function ImpressionArea<T extends ElementType = 'div'>({
-  as,
-  rootMargin,
-  areaThreshold,
-  timeThreshold,
-  onImpressionStart,
-  onImpressionEnd,
-  ref,
-  ...props
-}: Props<T>) {
-  const Component = as ?? 'div';
-  const impressionRef = useImpressionRef<HTMLElement>({
-    onImpressionStart,
-    onImpressionEnd,
-    areaThreshold,
-    timeThreshold,
-    rootMargin,
-  });
+export const ImpressionArea = forwardRef(
+  <T extends ElementType = 'div'>(
+    { as, rootMargin, areaThreshold, timeThreshold, onImpressionStart, onImpressionEnd, ...props }: Props<T>,
+    ref: React.Ref<Element>
+  ) => {
+    const Component = as ?? 'div';
+    const impressionRef = useImpressionRef<HTMLElement>({
+      onImpressionStart,
+      onImpressionEnd,
+      areaThreshold,
+      timeThreshold,
+      rootMargin,
+    });
 
-  return <Component ref={mergeRefs(ref, impressionRef)} {...props} />;
-}
+    return <Component ref={mergeRefs(ref, impressionRef)} {...props} />;
+  }
+);
+
+ImpressionArea.displayName = 'ImpressionArea';


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

In React versions below 18, it is not possible to pass a ref without using forwardRef.

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
