### PR TITLE
feat(SwitchCase): add support for symbol type

### DIFF
--- a/src/components/SwitchCase/SwitchCase.spec.tsx
+++ b/src/components/SwitchCase/SwitchCase.spec.tsx
@@ -60,6 +60,23 @@ describe('SwitchCase', () => {
     expect(screen.getByText('One')).toBeInTheDocument();
   });
 
+  it('should render correct component for symbol value', () => {
+    const symbolA = Symbol('symbol-a');
+    const symbolB = Symbol('symbol-b');
+
+    render(
+      <SwitchCase
+        value={symbolA}
+        caseBy={{
+          [symbolA]: () => <div>Symbol A Component</div>,
+          [symbolB]: () => <div>Symbol B Component</div>,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Symbol A Component')).toBeInTheDocument();
+  });
+
   it('should render default component when case not found', () => {
     const getStringValue = () => {
       const value = 'c';

--- a/src/components/SwitchCase/SwitchCase.spec.tsx
+++ b/src/components/SwitchCase/SwitchCase.spec.tsx
@@ -128,6 +128,22 @@ describe('SwitchCase', () => {
     expect(screen.getByText('True Case')).toBeInTheDocument();
   });
 
+  it('should render nothing when boolean value has no matching case', () => {
+    const value = false;
+
+    const { container } = render(
+      <SwitchCase
+        value={value}
+        caseBy={{
+          true: () => <div>True Case</div>,
+        }}
+        defaultComponent={() => null}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
   it('should render nothing when no matching case and default is null', () => {
     const getValue = () => {
       const value = undefined;

--- a/src/components/SwitchCase/SwitchCase.tsx
+++ b/src/components/SwitchCase/SwitchCase.tsx
@@ -1,9 +1,6 @@
 import { ReactElement } from 'react';
 
-type StringifiedValue<T> =
-  | (T extends boolean ? 'true' | 'false' : never)
-  | (T extends number ? `${T}` : never)
-  | (T extends string ? T : never);
+type StringifiedValue<T> = (T extends boolean ? 'true' | 'false' : never) | (T extends PropertyKey ? T : never);
 
 type Props<Case> = {
   value: Case;
@@ -45,6 +42,10 @@ type Props<Case> = {
  * }
  */
 export function SwitchCase<Case>({ value, caseBy, defaultComponent = () => null }: Props<Case>): ReactElement | null {
-  const stringifiedValue = String(value) as StringifiedValue<Case>;
-  return (caseBy[stringifiedValue] ?? defaultComponent)();
+  if (typeof value === 'boolean') {
+    const stringifiedValue = String(value) as StringifiedValue<Case>;
+    return (caseBy[stringifiedValue] ?? defaultComponent)();
+  }
+
+  return (caseBy[value as StringifiedValue<Case>] ?? defaultComponent)();
 }


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

This PR extends the `SwitchCase` component to support `symbol` type in addition to `boolean`, `string`, and `number`.

However, I'm somewhat concerned this might be over-engineering since symbol usage in typical React applications is relatively rare. I'd appreciate any feedback or thoughts on whether this addition provides sufficient value to justify the complexity.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
