### PR TITLE
docs(useInputState): type re-definition

### DIFF
--- a/src/hooks/useInputState/ko/useInputState.md
+++ b/src/hooks/useInputState/ko/useInputState.md
@@ -8,7 +8,7 @@
 function useInputState(
   initialValue: string = '',
   transformValue: (value: string) => string = (v: string) => v
-): [value: string, onChange: (value: string) => void];
+): [value: string, onChange: ChangeEventHandler<HTMLInputElement>];
 ```
 
 ### 파라미터
@@ -29,7 +29,7 @@ function useInputState(
 
 <Interface
   name=""
-  type="[value: string, onChange: (value: string) => void]"
+  type="[value: string, onChange: ChangeEventHandler<HTMLInputElement>]"
   description="튜플을 포함해요:"
   :nested="[
     {
@@ -39,7 +39,7 @@ function useInputState(
     },
     {
       name: 'onChange',
-      type: '(value: string) => void',
+      type: 'ChangeEventHandler<HTMLInputElement>',
       description: '상태를 업데이트하는 함수예요.',
     },
   ]"
@@ -49,7 +49,7 @@ function useInputState(
 
 ```tsx
 function Example() {
-  const [value, setValue] = useInputState('');
-  return <input type="text" value={value} onChange={setValue} />;
+  const [value, onChange] = useInputState('');
+  return <input type="text" value={value} onChange={onChange} />;
 }
 ```

--- a/src/hooks/useInputState/useInputState.md
+++ b/src/hooks/useInputState/useInputState.md
@@ -8,7 +8,7 @@
 function useInputState(
   initialValue: string = '',
   transformValue: (value: string) => string = (v: string) => v
-): [value: string, onChange: (value: string) => void];
+): [value: string, onChange: ChangeEventHandler<HTMLInputElement>];
 ```
 
 ### Parameters
@@ -29,7 +29,7 @@ function useInputState(
 
 <Interface
   name=""
-  type="[value: string, onChange: (value: string) => void]"
+  type="[value: string, onChange: ChangeEventHandler<HTMLInputElement>]"
   description="tuple containing:"
   :nested="[
     {
@@ -39,7 +39,7 @@ function useInputState(
     },
     {
       name: 'onChange',
-      type: '(value: string) => void',
+      type: 'ChangeEventHandler<HTMLInputElement>',
       description: 'A function to update the state.',
     },
   ]"
@@ -49,7 +49,7 @@ function useInputState(
 
 ```tsx
 function Example() {
-  const [value, setValue] = useInputState('');
-  return <input type="text" value={value} onChange={setValue} />;
+  const [value, onChange] = useInputState('');
+  return <input type="text" value={value} onChange={onChange} />;
 }
 ```

--- a/src/hooks/useInputState/useInputState.spec.ts
+++ b/src/hooks/useInputState/useInputState.spec.ts
@@ -8,13 +8,13 @@ import { useInputState } from './useInputState.ts';
 
 function createTestInput(...params: Parameters<typeof useInputState>) {
   return function Input() {
-    const [value, handleValueChange] = useInputState(...params);
+    const [value, onChange] = useInputState(...params);
 
     return createElement('input', {
       'data-testid': 'input',
       type: 'text',
       value,
-      onChange: handleValueChange,
+      onChange,
     });
   };
 }

--- a/src/hooks/useInputState/useInputState.ts
+++ b/src/hooks/useInputState/useInputState.ts
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, useCallback, useState } from 'react';
+import { ChangeEvent, ChangeEventHandler, useCallback, useState } from 'react';
 
 /**
  * @description
@@ -8,21 +8,21 @@ import { ChangeEventHandler, useCallback, useState } from 'react';
  * @param {(value: string) => string} [transformValue=(v: string) => v] - A function to transform the input value.
  *   Defaults to an identity function that returns the input unchanged.
  *
- * @returns {[value: string, onChange: (value: string) => void]} A tuple containing:
+ * @returns {[value: string, onChange: ChangeEventHandler<HTMLInputElement>]} A tuple containing:
  * - value `string` - The current state value;
- * - onChange `(value: string) => void` - A function to update the state;
+ * - onChange `ChangeEventHandler<HTMLInputElement>` - A function to update the state;
  *
  * @example
  * function Example() {
- *   const [value, setValue] = useInputState('');
- *   return <input type="text" value={value} onChange={setValue} />;
+ *   const [value, onChange] = useInputState('');
+ *   return <input type="text" value={value} onChange={onChange} />;
  * }
  */
 export function useInputState(initialValue = '', transformValue: (value: string) => string = echo) {
   const [value, setValue] = useState(initialValue);
 
-  const handleValueChange: ChangeEventHandler<HTMLElement & { value: string }> = useCallback(
-    ({ target: { value } }) => {
+  const handleValueChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
       setValue(transformValue(value));
     },
     [transformValue]


### PR DESCRIPTION
# Overview

useInputState의 handleValueChange 의 반환 타입과 실제 사용 예제 코드가 알맞지 않아서, 타입 정의를 명확히 하고 handleValueChange 함수를 용도에 맞게 사용하도록 에제 코드도 수정하였습니다.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
