### PR TITLE
fix(useOutsideClickEffect): restrict event type to MouseEvent in handleDocumentClick

### DIFF
--- a/src/hooks/useOutsideClickEffect/useOutsideClickEffect.ts
+++ b/src/hooks/useOutsideClickEffect/useOutsideClickEffect.ts
@@ -30,7 +30,7 @@ type OneOrMore<T> = T | T[];
 export function useOutsideClickEffect(container: OneOrMore<HTMLElement | null>, callback: () => void) {
   const containers = useRef<HTMLElement[]>([]);
 
-  const handleDocumentClick = usePreservedCallback(({ target }: MouseEvent | TouchEvent) => {
+  const handleDocumentClick = usePreservedCallback(({ target }: MouseEvent) => {
     if (target === null) {
       return;
     }


### PR DESCRIPTION
# Overview
This PR resolves a type mismatch in `useOutsideClickEffect` where the event handler incorrectly expected `TouchEvent` while only listening to `click` events. The changes ensure type consistency between event listeners and handlers.


## Reason for Change
1. **Type Safety**  
   The hook was listening exclusively to `click` events (which fire `MouseEvent`), but the handler accepted `MouseEvent | TouchEvent`. This caused:
   - TypeScript type errors
   - Potential runtime inconsistencies

## Checklist

- [ ] Did you write the test code?
- [X] Have you run `yarn run fix` to format and lint the code and docs?
- [X] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
