### PR TITLE
fix(useAsyncEffect): Replace void with undefined in useAsyncEffect hook types

### DIFF
--- a/src/hooks/useAsyncEffect/ko/useAsyncEffect.md
+++ b/src/hooks/useAsyncEffect/ko/useAsyncEffect.md
@@ -6,7 +6,7 @@
 
 ```ts
 function useAsyncEffect(
-  effect: () => Promise<void | (() => void)>,
+  effect: () => Promise<undefined | (() => void)>,
   deps: DependencyList
 ): void;
 ```
@@ -15,7 +15,7 @@ function useAsyncEffect(
 
 <Interface
   name="effect"
-  type="() => Promise<void | (() => void)>"
+  type="() => Promise<undefined | (() => void)>"
   description="<code>useEffect</code> 패턴으로 실행되는 비동기 함수예요. 이 함수는 선택적으로 정리(clean-up) 함수를 반환할 수 있어요."
 />
 

--- a/src/hooks/useAsyncEffect/useAsyncEffect.md
+++ b/src/hooks/useAsyncEffect/useAsyncEffect.md
@@ -6,7 +6,7 @@
 
 ```ts
 function useAsyncEffect(
-  effect: () => Promise<void | (() => void)>,
+  effect: () => Promise<undefined | (() => void)>,
   deps: DependencyList
 ): void;
 ```
@@ -15,7 +15,7 @@ function useAsyncEffect(
 
 <Interface
   name="effect"
-  type="() => Promise<void | (() => void)>"
+  type="() => Promise<undefined | (() => void)>"
   description="An asynchronous function executed in the <code>useEffect</code> pattern. This function can optionally return a cleanup function."
 />
 

--- a/src/hooks/useAsyncEffect/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect/useAsyncEffect.ts
@@ -5,7 +5,7 @@ import { DependencyList, useEffect } from 'react';
  * `useAsyncEffect` is a React hook for handling asynchronous side effects in React components.
  * It follows the same cleanup pattern as `useEffect` while ensuring async operations are handled safely.
  *
- * @param {() => Promise<void | (() => void)>} [effect] - An asynchronous function executed in the `useEffect` pattern.
+ * @param {() => Promise<undefined | (() => void)>} [effect] - An asynchronous function executed in the `useEffect` pattern.
  *   This function can optionally return a cleanup function.
  * @param {DependencyList} [deps] - A dependency array.
  *   The effect will re-run whenever any value in this array changes. If omitted, it runs only once when the component mounts.
@@ -21,9 +21,9 @@ import { DependencyList, useEffect } from 'react';
  * }, [dependencies]);
  */
 
-export function useAsyncEffect(effect: () => Promise<void | (() => void)>, deps?: DependencyList) {
+export function useAsyncEffect(effect: () => Promise<undefined | (() => void)>, deps?: DependencyList) {
   useEffect(() => {
-    let cleanup: (() => void) | void;
+    let cleanup: undefined | (() => void);
 
     effect().then(result => {
       cleanup = result;


### PR DESCRIPTION
# Overview

This PR updates the type definitions in the `useAsyncEffect` hook to replace `void` with `undefined` for better type safety and linter compatibility.

## Changes

- Updated function parameter type from `() => Promise<void | (() => void)>` to `() => Promise<undefined | (() => void)>`
- Updated local variable type from `(() => void) | void` to `undefined | (() => void)`
- Updated JSDoc comments to reflect the type changes


## Reason for Change

1. Runtime Accuracy
In JavaScript, functions that don't explicitly return a value actually return `undefined`, not `void`. The `void` type is a TypeScript construct that represents the absence of a return value, but at runtime, this is always `undefined`.

```ts
typescript
// What actually happens at runtime
const result = await effect(); // result is undefined when no cleanup function is returned
cleanup = result; // cleanup becomes undefined, not void
```

2. Linter Compatibility
Using void in union types can trigger linting errors in modern tools:
- Biome's `noConfusingVoidType`: Flags `void` usage in type unions as potentially confusing
- Better consistency: `undefined` is more explicit about the actual runtime value

3. Type System Consistency
The optional chaining operator (`cleanup?.()`) is designed to work with `undefined` and `null` values. Using `undefined` makes the intent clearer and aligns with JavaScript's actual behavior.

4. Developer Experience
`undefined` is more intuitive for developers as it represents the actual value they'll encounter during debugging and development.

This change maintains full backward compatibility while improving type accuracy and eliminating potential linter warnings.

## Reference
[Biome - noConfusingVoidType](https://biomejs.dev/linter/rules/no-confusing-void-type/)

## Checklist

- [ ] Did you write the test code?
- [X] Have you run `yarn run fix` to format and lint the code and docs?
- [X] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [X] Did you write the JSDoc?
