### PR TITLE
docs(useMap): fix code block formatting

### DIFF
--- a/src/hooks/useMap/useMap.md
+++ b/src/hooks/useMap/useMap.md
@@ -27,8 +27,9 @@ function useMap(initialState: MapOrEntries<K, V>): UseMapReturn<K, V>;
 
 ## Example
 
-````tsx
 ```tsx
+import { useMap } from 'react-simplikit';
+
 const [userMap, actions] = useMap<string, User>([
   ['user1', { name: 'John', age: 30 }]
 ]);
@@ -38,8 +39,4 @@ const user1 = userMap.get('user1');
 
 // Updating the Map
 actions.set('user2', { name: 'Jane', age: 25 });
-````
-
-```
-
 ```


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->

Fix code block formatting in [useMap.md](https://react-simplikit.slash.page/hooks/useMap.html) example.

Before the change, it's as shown in the first image below, and after the change, it's as shown in the second image

<img width="727" alt="image" src="https://github.com/user-attachments/assets/788fc681-b138-4f30-87ba-407728442c04" />

<img width="754" alt="image" src="https://github.com/user-attachments/assets/19b936aa-7b86-44b2-9f83-4e4c5fd89f05" />


## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
