### PR TITLE
docs: fix useLongPress hook event handler descriptions and formatting

### DIFF
--- a/src/hooks/useLongPress/ko/useLongPress.md
+++ b/src/hooks/useLongPress/ko/useLongPress.md
@@ -83,40 +83,40 @@ function useLongPress<E extends HTMLElement>(
     },
      {
       name: 'onMouseUp',
-      type: '(event : MouseEvent<E> | TouchEvent<E>) => void',
+      type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
       description:
         '마우스 업 이벤트에 대한 이벤트 핸들러예요.',
     },
-        {
+    {
       name: 'onMouseLeave',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
-      description: '마우스 리브 이벤트에 대한 이벤트 핸들러예요.'
+      description: '마우스 리브 이벤트에 대한 이벤트 핸들러예요.',
     },
     {
       name: 'onTouchStart',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
-      description: '터치 시작 이벤트에 대한 이벤트 핸들러예요.'
+      description: '터치 시작 이벤트에 대한 이벤트 핸들러예요.',
     },
     {
       name: 'onTouchEnd',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
-      description: '터치 종료 이벤트에 대한 이벤트 핸들러예요.'
+      description: '터치 종료 이벤트에 대한 이벤트 핸들러예요.',
     },
     {
       name: 'onMouseMove',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
-      description: '마우스 이동 이벤트에 대한 이벤트 핸들러예요. 만약 <code>moveThreshold</code>가 제공되면 포함돼요.'
+      description: '마우스 이동 이벤트에 대한 이벤트 핸들러예요. 만약 <code>moveThreshold</code>가 제공되면 포함돼요.',
     },
     {
       name: 'onTouchMove',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
-      description: '터치 이동 이벤트에 대한 이벤트 핸들러예요. 만약 <code>moveThreshold</code>가 제공되면 포함돼요.'
+      description: '터치 이동 이벤트에 대한 이벤트 핸들러예요. 만약 <code>moveThreshold</code>가 제공되면 포함돼요.',
     }
   ]"
 />

--- a/src/hooks/useLongPress/useLongPress.md
+++ b/src/hooks/useLongPress/useLongPress.md
@@ -79,49 +79,49 @@ function useLongPress<E extends HTMLElement>(
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
       description:
-        'Event handler for mouse down events.'
+        'Event handler for mouse down events.',
     },
     {
       name: 'onMouseUp',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
       description:
-        'Event handler for mouse up events.'
+        'Event handler for mouse up events.',
     },
     {
       name: 'onMouseLeave',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
       description:
-        'Event handler for mouse leave events.'
+        'Event handler for mouse leave events.',
     },
     {
       name: 'onTouchStart',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
       description:
-        'Event handler for touch start events.'
+        'Event handler for touch start events.',
     },
     {
       name: 'onTouchEnd',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
       description:
-        'Event handler for touch end events.'
+        'Event handler for touch end events.',
     },
     {
       name: 'onMouseMove',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
       description:
-        'Event handler for mouse move events. Included if <code>moveThreshold</code> is provided.'
+        'Event handler for mouse move events. Included if <code>moveThreshold</code> is provided.',
     },
     {
       name: 'onTouchMove',
       type: '(event: MouseEvent<E> | TouchEvent<E>) => void',
       required: false,
       description:
-        'Event handler for touch move events. Included if <code>moveThreshold</code> is provided.'
+        'Event handler for touch move events. Included if <code>moveThreshold</code> is provided.',
     }
   ]"
 />


### PR DESCRIPTION
# Overview

This PR improves the `useLongPress` hook documentation by fixing the broken structure and formatting of event handler descriptions. It separates each handler clearly for better readability and accuracy.

| Before | After |
|:------:|:-----:|
| <img width="748" height="533" alt="스크린샷 2025-09-12 오후 9 10 17" src="https://github.com/user-attachments/assets/ca4eeeb4-d752-4e0d-aaa2-611204e16b33" />|  <img width="665" height="553" alt="스크린샷 2025-09-12 오후 9 10 08" src="https://github.com/user-attachments/assets/1bfc6d84-31fa-4b18-a531-79e163495ab1" />|

## Checklist

- [ ] Did you write the test code?
- [X] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
