### PR TITLE
docs: Improve readability of condition prop description for dependency functions

### DIFF
--- a/src/hooks/useConditionalEffect/ko/useConditionalEffect.md
+++ b/src/hooks/useConditionalEffect/ko/useConditionalEffect.md
@@ -32,7 +32,7 @@ function useConditionalEffect(
   required
   name="condition"
   type="(prevDeps: T | undefined, currentDeps: T) => boolean"
-  description="이전 및 현재 의존성을 기반으로 효과를 실행할지 결정하는 함수예요. - 초기 렌더링 시, <code>prevDeps</code>는 <code>undefined</code>일 거예요. <code>condition</code> 함수는 이 경우를 처리해야 해요. - 초기 렌더링 시 효과를 실행하려면, <code>prevDeps</code>가 <code>undefined</code>일 때 <code>true</code>를 반환하면 돼요. - 초기 렌더링 시 효과를 실행하고 싶지 않다면, <code>prevDeps</code>가 <code>undefined</code>일 때 <code>false</code>를 반환하면 돼요."
+  description="이전 및 현재 의존성을 기반으로 효과를 실행할지 결정하는 함수예요. <br /> - 초기 렌더링 시, <code>prevDeps</code>는 <code>undefined</code>일 거예요. <code>condition</code> 함수는 이 경우를 처리해야 해요. <br /> - 초기 렌더링 시 효과를 실행하려면, <code>prevDeps</code>가 <code>undefined</code>일 때 <code>true</code>를 반환하면 돼요. <br /> - 초기 렌더링 시 효과를 실행하고 싶지 않다면, <code>prevDeps</code>가 <code>undefined</code>일 때 <code>false</code>를 반환하면 돼요."
 />
 
 ### 반환 값

--- a/src/hooks/useConditionalEffect/useConditionalEffect.md
+++ b/src/hooks/useConditionalEffect/useConditionalEffect.md
@@ -32,7 +32,7 @@ function useConditionalEffect(
   required
   name="condition"
   type="(prevDeps: T | undefined, currentDeps: T) => boolean"
-  description="Function that determines if the effect should run based on previous and current deps. - On the initial render, <code>prevDeps</code> will be <code>undefined</code>. Your <code>condition</code> function should handle this case. - If you want your effect to run on the initial render, return <code>true</code> when <code>prevDeps</code> is <code>undefined</code>. - If you don\'t want your effect to run on the initial render, return <code>false</code> when <code>prevDeps</code> is <code>undefined</code>."
+  description="Function that determines if the effect should run based on previous and current deps. <br /> - On the initial render, <code>prevDeps</code> will be <code>undefined</code>. Your <code>condition</code> function should handle this case. <br /> - If you want your effect to run on the initial render, return <code>true</code> when <code>prevDeps</code> is <code>undefined</code>. <br /> - If you don\'t want your effect to run on the initial render, return <code>false</code> when <code>prevDeps</code> is <code>undefined</code>."
 />
 
 ### Return Value


### PR DESCRIPTION
# Overview

This PR refines the documentation for the `condition` prop by formatting the description for better readability in both Korean and English. Now, each behavioral case (about initial render and return values) is clearly separated using line breaks for easier understanding.

| Before | After |
|:------:|:-----:|
| <img width="784" height="460" alt="스크린샷 2025-09-13 오후 3 28 24" src="https://github.com/user-attachments/assets/245f9248-cee9-4487-89b6-b29917c76457" />|  <img width="799" height="468" alt="스크린샷 2025-09-13 오후 3 28 15" src="https://github.com/user-attachments/assets/38ca089e-f426-48ec-a325-ecfbcff76cf4" />|


## Checklist

- [ ] Did you write the test code?
- [X] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
