### PR TITLE
refactor(usePrevious): remove undefined from compare argument and return type

### DIFF
--- a/src/hooks/usePrevious/ko/usePrevious.md
+++ b/src/hooks/usePrevious/ko/usePrevious.md
@@ -7,8 +7,8 @@
 ```ts
 function usePrevious<T>(
   state: T,
-  compare: (prev: T | undefined, next: T) => boolean
-): T | undefined;
+  compare: (prev: T, next: T) => boolean
+): T;
 ```
 
 ### 파라미터
@@ -22,7 +22,7 @@ function usePrevious<T>(
 
 <Interface
   name="compare"
-  type="(prev: T | undefined, next: T) => boolean"
+  type="(prev: T, next: T) => boolean"
   description="상태가 변경되었는지를 판단하기 위한 선택적 비교 함수예요."
 />
 
@@ -30,7 +30,7 @@ function usePrevious<T>(
 
 <Interface
   name=""
-  type="T | undefined"
+  type="T"
   description="상태의 이전 값이에요."
 />
 

--- a/src/hooks/usePrevious/usePrevious.md
+++ b/src/hooks/usePrevious/usePrevious.md
@@ -7,8 +7,8 @@
 ```ts
 function usePrevious<T>(
   state: T,
-  compare: (prev: T | undefined, next: T) => boolean
-): T | undefined;
+  compare: (prev: T, next: T) => boolean
+): T;
 ```
 
 ### Parameters
@@ -22,7 +22,7 @@ function usePrevious<T>(
 
 <Interface
   name="compare"
-  type="(prev: T | undefined, next: T) => boolean"
+  type="(prev: T, next: T) => boolean"
   description="An optional comparison function to determine if the state has changed."
 />
 
@@ -30,7 +30,7 @@ function usePrevious<T>(
 
 <Interface
   name=""
-  type="T | undefined"
+  type="T"
   description="previous value of the state."
 />
 

--- a/src/hooks/usePrevious/usePrevious.ts
+++ b/src/hooks/usePrevious/usePrevious.ts
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 
-const strictEquals = <T>(prev: T | undefined, next: T) => prev === next;
+const strictEquals = <T>(prev: T, next: T) => prev === next;
 
 /**
  * @description
@@ -11,9 +11,9 @@ const strictEquals = <T>(prev: T | undefined, next: T) => prev === next;
  *
  * @template T - The type of the state.
  * @param {T} state - The state whose previous value is to be tracked.
- * @param {(prev: T | undefined, next: T) => boolean} [compare] - An optional comparison function to determine if the state has changed.
+ * @param {(prev: T, next: T) => boolean} [compare] - An optional comparison function to determine if the state has changed.
  *
- * @returns {T | undefined} The previous value of the state.
+ * @returns {T} The previous value of the state.
  *
  * @example
  * const [count, setCount] = useState(0);


### PR DESCRIPTION
# Overview

This PR updates both the code and documentation for the `usePrevious` hook to remove `undefined` from the `compare` function's argument types and from the return type.

Since the state parameter passed to the hook is a required value and always provided, and the initial `state` is stored in `prevRef`, the prev argument never becomes undefined during the hook's lifecycle. Thus, the hook also never returns `undefined`.

This update ensures consistency between implementation, type definitions, and documentation, clarifying the intended usage.

| Before | After |
|:------:|:-----:|
|  <img width="745" height="557" alt="스크린샷 2025-09-13 오후 3 47 08" src="https://github.com/user-attachments/assets/41e537d9-d4d5-483f-9444-d371e5bb58c9" />|  <img width="759" height="551" alt="스크린샷 2025-09-13 오후 3 47 16" src="https://github.com/user-attachments/assets/e6ffdea7-4757-414c-95d4-32051bc9f10d" />|


## Checklist

- [ ] Did you write the test code?
- [X] Have you run `yarn run fix` to format and lint the code and docs?
- [X] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
