### PR TITLE
docs(useStorageState): Clarify serializer and deserializer function types

### DIFF
--- a/src/hooks/useStorageState/ko/useStorageState.md
+++ b/src/hooks/useStorageState/ko/useStorageState.md
@@ -5,7 +5,7 @@
 ## 인터페이스
 
 ```ts
-function useStorageState(
+function useStorageState<T>(
   key: string,
   options: Object
 ): readonly [
@@ -45,13 +45,13 @@ function useStorageState(
     },
     {
       name: 'options.serializer',
-      type: 'Function',
+      type: '(value: Serializable<T>) => string',
       required: false,
       description: '상태 값을 문자열로 직렬화하는 함수예요.',
     },
     {
       name: 'options.deserializer',
-      type: 'Function',
+      type: '(value: string) => Serializable<T>',
       required: false,
       description: '상태 값을 문자열에서 역직렬화하는 함수예요.',
     },

--- a/src/hooks/useStorageState/useStorageState.md
+++ b/src/hooks/useStorageState/useStorageState.md
@@ -45,13 +45,13 @@ function useStorageState(
     },
     {
       name: 'options.serializer',
-      type: 'Function',
+      type: '(value: Serializable<T>) => string',
       required: false,
       description: 'A function to serialize the state value to a string.',
     },
     {
       name: 'options.deserializer',
-      type: 'Function',
+      type: '(value: string) => Serializable<T>',
       required: false,
       description: 'A function to deserialize the state value from a string.',
     },

--- a/src/hooks/useStorageState/useStorageState.ts
+++ b/src/hooks/useStorageState/useStorageState.ts
@@ -70,8 +70,8 @@ const ensureSerializable = <T extends readonly any[]>(value: T): SerializableGua
  * @param {Object} [options] - Configuration options for storage behavior.
  * @param {Storage} [options.storage=localStorage] - The storage type (`localStorage` or `sessionStorage`). Defaults to `localStorage`.
  * @param {T} [options.defaultValue] - The initial value if no existing value is found.
- * @param {Function} [options.serializer] - A function to serialize the state value to a string.
- * @param {Function} [options.deserializer] - A function to deserialize the state value from a string.
+ * @param {(value: Serializable<T>) => string} [options.serializer] - A function to serialize the state value to a string.
+ * @param {(value: string) => Serializable<T>} [options.deserializer] - A function to deserialize the state value from a string.
  *
  * @returns {readonly [state: Serializable<T> | undefined, setState: (value: SetStateAction<Serializable<T> | undefined>) => void, refreshState: () => void]} A tuple:
  * - state `Serializable<T> | undefined` - The current state value retrieved from storage;


### PR DESCRIPTION
# Overview

This PR improves the documentation of the `useStorageState` hook by explicitly specifying the types of the `serializer` and `deserializer` functions in the options parameter.  

By defining `serializer` as `(value: Serializable<T>) => string` and `deserializer` as `(value: string) => Serializable<T>`, users can better understand the expected input and output types, enhancing code safety and usability.  

This clarification helps users implement custom serialization logic correctly and improves the overall DX.

| Before | After |
|:------:|:-----:|
| <img width="744" height="745" alt="스크린샷 2025-09-13 오후 4 35 00" src="https://github.com/user-attachments/assets/0e5b8d0f-3df0-47b0-af5f-d78aee29973b" />|<img width="738" height="743" alt="스크린샷 2025-09-13 오후 4 34 43" src="https://github.com/user-attachments/assets/00321fb9-5661-4052-8d48-838d30ae4a51" />|

## Checklist

- [ ] Did you write the test code?
- [X] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
