### PR TITLE
docs(useThrottle): clarify defaultValue initial value description

### DIFF
--- a/src/hooks/useThrottle/ko/useThrottle.md
+++ b/src/hooks/useThrottle/ko/useThrottle.md
@@ -39,7 +39,7 @@ function useThrottle<F extends (...args: any[]) => any>(
       required: false,
       defaultValue: '[\'leading\', \'trailing\']',
       description:
-        '함수가 시작점, 끝점 또는 둘 다에서 호출될지 여부를 지정하는 선택적 배열이에요.',
+        '함수가 시작점, 끝점 또는 둘 다에서 호출될지 여부를 지정하는 선택적 배열이에요. <br /> : 초기값은 <code>[\'leading\', \'trailing\']</code>이에요.',
     },
   ]"
 />

--- a/src/hooks/useThrottle/useThrottle.md
+++ b/src/hooks/useThrottle/useThrottle.md
@@ -39,7 +39,7 @@ function useThrottle<F extends (...args: any[]) => any>(
       required: false,
       defaultValue: '[\'leading\', \'trailing\']',
       description:
-        'An optional array specifying whether the function should be invoked on the leading edge, trailing edge, or both.',
+        'An optional array specifying whether the function should be invoked on the leading edge, trailing edge, or both. <br /> : The initial value is <code>[\'leading\', \'trailing\']</code>.',
     },
   ]"
 />


### PR DESCRIPTION
# Overview

This PR improves the documentation of the `useThrottle` hook by explicitly clarifying that the `options.edges` property's `defaultValue` represents the initial value.  

While the defaultValue attribute already indicates the initial value, for users new to react-simplikit and its docs, it may not be immediately obvious visually.  

Therefore, this description adds a clear note that the initial value is `['leading', 'trailing']` to enhance usability and maintain consistency with other documentation styles in the codebase.  

| Before | After |
|:------:|:-----:|
|  <img width="746" height="572" alt="스크린샷 2025-09-13 오후 4 52 08" src="https://github.com/user-attachments/assets/ad9c9888-c88c-4ec2-bccd-ac0db216e63c" />|  <img width="753" height="602" alt="스크린샷 2025-09-13 오후 4 51 55" src="https://github.com/user-attachments/assets/71b34158-78b0-41b2-9480-6ce20d46cfad" />|

This change follows the documentation style exemplified in the [useLoading Docs](https://react-simplikit.slash.page/ko/hooks/useLoading.html#%E1%84%87%E1%85%A1%E1%86%AB%E1%84%92%E1%85%AA%E1%86%AB-%E1%84%80%E1%85%A1%E1%86%B9).

## Checklist

- [ ] Did you write the test code?
- [X] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
