### PR TITLE
refactor(useVisibilityEvent): optimize useVisibilityEvent hook with usePreservedCallback to prevent unnecessary effect

### DIFF
--- a/src/hooks/useVisibilityEvent/ko/useVisibilityEvent.md
+++ b/src/hooks/useVisibilityEvent/ko/useVisibilityEvent.md
@@ -31,7 +31,7 @@ function useVisibilityEvent(
       required: false,
       defaultValue: 'false',
       description:
-        'true이면, 현재 가시성 상태로 마운트 시에 즉시 콜백이 호출돼요.',
+        'true이면, 현재 가시성 상태로 마운트 시에 즉시 콜백이 호출돼요. <br />: 초기값은 <code>false</code>이에요.',
     },
   ]"
 />

--- a/src/hooks/useVisibilityEvent/useVisibilityEvent.md
+++ b/src/hooks/useVisibilityEvent/useVisibilityEvent.md
@@ -31,7 +31,7 @@ function useVisibilityEvent(
       required: false,
       defaultValue: 'false',
       description:
-        'If true, the callback is invoked immediately upon mounting with the current visibility state.',
+        'If true, the callback is invoked immediately upon mounting with the current visibility state. <br />: The initial value is <code>false</code>.',
     },
   ]"
 />

--- a/src/hooks/useVisibilityEvent/useVisibilityEvent.ts
+++ b/src/hooks/useVisibilityEvent/useVisibilityEvent.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
+
+import { usePreservedCallback } from '../usePreservedCallback/index.ts';
 
 type Options = {
   immediate?: boolean;
@@ -27,9 +29,7 @@ type Options = {
  */
 
 export function useVisibilityEvent(callback: (visibilityState: 'visible' | 'hidden') => void, options: Options = {}) {
-  const handleVisibilityChange = useCallback(() => {
-    callback(document.visibilityState);
-  }, [callback]);
+  const handleVisibilityChange = usePreservedCallback(() => callback(document.visibilityState));
 
   useEffect(() => {
     if (options?.immediate ?? false) {


### PR DESCRIPTION
# Overview

This PR refactors the `useVisibilityEvent` hook to use `usePreservedCallback` for the visibility change handler.  

By doing so, the `handleVisibilityChange` function reference remains stable across component re-renders, preventing `useEffect` from unnecessarily re-executing and re-attaching event listeners.  

This reduces the overhead of continuously adding and removing the `visibilitychange` event listener, providing a performance boost.  

Additionally, even when the `callback` changes, `usePreservedCallback` ensures the latest callback is always invoked, maintaining correctness.

Added initial values ​​to the `options.immediate` documentation.

## Checklist

- [ ] Did you write the test code?
- [X] Have you run `yarn run fix` to format and lint the code and docs?
- [X] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
