### PR TITLE
refactor(buildContext): added displayName and fixed useInnerContext branch handling

### DIFF
--- a/src/utils/buildContext/buildContext.md
+++ b/src/utils/buildContext/buildContext.md
@@ -5,7 +5,7 @@
 ## Interface
 
 ```ts
-function buildContext(
+function buildContext<ContextValuesType extends object>(
   contextName: string,
   defaultContextValues: ContextValuesType
 ): [
@@ -54,7 +54,7 @@ function buildContext(
 ```tsx
 const [Provider, useContext] = buildContext<{ title: string }>(
   'TestContext',
-  null
+  { title: "" },
 );
 
 function Inner() {

--- a/src/utils/buildContext/buildContext.tsx
+++ b/src/utils/buildContext/buildContext.tsx
@@ -45,6 +45,8 @@ export function buildContext<ContextValuesType extends object>(
     return <Context.Provider value={value}>{children}</Context.Provider>;
   }
 
+  Object.assign(Provider, { displayName: `${contextName}Provider` });
+
   function useInnerContext() {
     const context = useContext(Context);
 

--- a/src/utils/buildContext/buildContext.tsx
+++ b/src/utils/buildContext/buildContext.tsx
@@ -33,7 +33,7 @@ export function buildContext<ContextValuesType extends object>(
   contextName: string,
   defaultContextValues?: ContextValuesType
 ) {
-  const Context = createContext<ContextValuesType | undefined>(defaultContextValues ?? undefined);
+  const Context = createContext<ContextValuesType | null>(defaultContextValues ?? null);
 
   function Provider({ children, ...contextValues }: ProviderProps<ContextValuesType>) {
     const value = useMemo(
@@ -48,11 +48,11 @@ export function buildContext<ContextValuesType extends object>(
   function useInnerContext() {
     const context = useContext(Context);
 
-    if (context != null) {
+    if (context !== null) {
       return context;
     }
 
-    if (defaultContextValues != null) {
+    if (defaultContextValues !== undefined) {
       return defaultContextValues;
     }
 

--- a/src/utils/buildContext/ko/buildContext.md
+++ b/src/utils/buildContext/ko/buildContext.md
@@ -5,7 +5,7 @@
 ## 인터페이스
 
 ```ts
-function buildContext(
+function buildContext<ContextValuesType extends object>(
   contextName: string,
   defaultContextValues: ContextValuesType
 ): [
@@ -54,7 +54,7 @@ function buildContext(
 ```tsx
 const [Provider, useContext] = buildContext<{ title: string }>(
   'TestContext',
-  null
+  { title: "" },
 );
 
 function Inner() {


### PR DESCRIPTION
# Overview

1. Modifying the initial values ​​of the `buildContext` example document

In the example, `null` is passed as the second argument, but since the signature of `buildContext` is as follows, `null` cannot be passed.
```ts
function buildContext<ContextValuesType extends object>(
  contextName: string,
  defaultContextValues?: ContextValuesType, // null cannot be inserted
)
```
Also, since we used the `<{ title: string }>` generic type, we cannot initialize it with `null`.

2. Absence of displayName from Provider

Currently, it is difficult to debug because there is no displayName for Provider, so the displayName is specified using the `contextName` prop.

| Before | After |
|:------:|:-----:|
| <img width="1164" height="470" alt="스크린샷 2025-09-15 오후 7 39 38" src="https://github.com/user-attachments/assets/6e68de92-617f-4320-9037-d4cc88e289c9" />|  <img width="1150" height="506" alt="스크린샷 2025-09-15 오후 7 40 03" src="https://github.com/user-attachments/assets/341b36f0-2d92-4805-83af-da037aee389e" />|

3. Fix branching of the useInnerContext function

Since the type declaration of Context is as follows, when reading the Context with `useContext`, it is inferred as `ContextValuesType | undefined`.
```ts
const Context = createContext<ContextValuesType | undefined>(
  defaultContextValues,
);
```
However, if there are no values ​​received as props within the Provider, `null` is returned. If props exist, the received props are returned.
```ts
const value = useMemo(
  () => (Object.keys(contextValues).length > 0 ? contextValues : null),
  // eslint-disable-next-line react-hooks/exhaustive-deps
  [...Object.values(contextValues)]
) as ContextValuesType;
```

Therefore, when reading `useContext`, `ContextValuesType | null` is actually returned, but the type system infers `ContextValuesType | undefined`.

To solve this complex and tangled type problem, the type of context was unified to `ContextValuesType | null` so that only `null` can be handled.
```ts
// as-is
const Context = createContext<ContextValuesType | undefined>(
  defaultContextValues,
);

const context = useContext(Context);
if (context != null) {
  return context;
}

// to-be
const Context = createContext<ContextValuesType | null>(defaultContextValues ?? null);

const context = useContext(Context);
if (context !== null) {
  return context;
}
```

Since the type of `defaultContextValues` ​​is `<ContextValuesType extends object> | undefined` , `null` cannot be provided, so there is no need to handle the case of `null`.
```ts
// as-is
if (defaultContextValues != null) {
  return defaultContextValues;
}

// to-be
if (defaultContextValues !== undefined) {
  return defaultContextValues;
}
```

## Checklist

- [ ] Did you write the test code?
- [X] Have you run `yarn run fix` to format and lint the code and docs?
- [X] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
