### PR TITLE
fix(useControlledState): fix multiple function set state actions problem

### DIFF
--- a/packages/core/src/hooks/useControlledState/useControlledState.spec.tsx
+++ b/packages/core/src/hooks/useControlledState/useControlledState.spec.tsx
@@ -115,4 +115,19 @@ describe('useControlledState', () => {
     const [nextValue] = result.current;
     expect(nextValue).toBe(8);
   });
+
+  it('should handle multiple function setState actions', async () => {
+    const { result } = renderHookSSR(() => useControlledState({ defaultValue: 5 }));
+    const [value] = result.current;
+    expect(value).toBe(5);
+
+    await act(async () => {
+      const [, setValue] = result.current;
+      setValue(prev => prev + 3);
+      setValue(prev => prev + 3);
+    });
+
+    const [nextValue] = result.current;
+    expect(nextValue).toBe(11);
+  });
 });

--- a/packages/core/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/core/src/hooks/useControlledState/useControlledState.ts
@@ -1,6 +1,7 @@
 import React, { type Dispatch, type SetStateAction, useCallback, useReducer, useRef, useState } from 'react';
 
 const useSafeInsertionEffect: typeof React.useLayoutEffect =
+  /* c8 ignore next */
   typeof document !== 'undefined' ? (React['useInsertionEffect'] ?? React.useLayoutEffect) : () => {};
 
 type ControlledState<T> = { value: T; defaultValue?: never } | { defaultValue: T; value?: T };

--- a/packages/core/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/core/src/hooks/useControlledState/useControlledState.ts
@@ -1,4 +1,7 @@
-import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
+import React, { type Dispatch, type SetStateAction, useCallback, useReducer, useRef, useState } from 'react';
+
+const useSafeInsertionEffect: typeof React.useLayoutEffect =
+  typeof document !== 'undefined' ? (React['useInsertionEffect'] ?? React.useLayoutEffect) : () => {};
 
 type ControlledState<T> = { value: T; defaultValue?: never } | { defaultValue: T; value?: T };
 
@@ -49,19 +52,35 @@ export function useControlledState<T>({
   equalityFn = Object.is,
 }: UseControlledStateProps<T>): [T, Dispatch<SetStateAction<T>>] {
   const [uncontrolledState, setUncontrolledState] = useState(defaultValue as T);
+  const valueRef = useRef(uncontrolledState);
+
   const controlled = valueProp !== undefined;
   const value = controlled ? valueProp : uncontrolledState;
 
+  // After each render, reset valueRef to the actual value.
+  // This keeps the ref in sync with the actual value after optimistic updates.
+  const [, triggerRerender] = useReducer(() => ({}), {});
+  useSafeInsertionEffect(() => {
+    valueRef.current = value;
+  });
+
   const setValue = useCallback(
     (next: SetStateAction<T>) => {
-      const nextValue = isSetStateAction(next) ? next(value) : next;
+      const nextValue = isSetStateAction(next) ? next(valueRef.current) : next;
 
-      if (equalityFn(value, nextValue) === true) return;
+      if (equalityFn(valueRef.current, nextValue) === true) return;
+
+      valueRef.current = nextValue;
+      // In controlled mode the parent may decide not to update the value
+      // (e.g. conditional logic inside onChange).
+      // Force a re-render so the effect above can resync the ref with the actual value.
+      triggerRerender();
+
       if (controlled === false) setUncontrolledState(nextValue);
       if (controlled === true && nextValue === undefined) setUncontrolledState(nextValue);
       onChange?.(nextValue);
     },
-    [controlled, onChange, equalityFn, value]
+    [controlled, onChange, equalityFn]
   );
 
   return [value, setValue];


### PR DESCRIPTION
# Overview
This PR improves useControlledState to correctly handle multiple functional setState actions executed within the same render cycle.

Previously, functional updates relied on a closure-captured value, which could lead to stale state when multiple updates were batched by React. This change introduces an internal valueRef to always compute the next state from the latest intermediate value.

Additionally, a safe insertion/layout effect is used to keep the ref synchronized with the actual state after each render, ensuring consistent behavior in both controlled and uncontrolled modes.

## Problem
`useControlledState` previously calculated the next value using the value captured in the closure.

`const nextValue = isSetStateAction(next) ? next(value) : next;`

When multiple functional setState actions were executed within the same render cycle, each updater received the same stale value, because React batches updates.

Example:

```
setValue(prev => prev + 3);
setValue(prev => prev + 3);

Expected result: 5 → 8 → 11

Actual result: 5 → 8
```

Both updates used the same previous value (5).

## Solution

To ensure each updater receives the latest intermediate value, this PR introduces an internal valueRef.

`const valueRef = useRef(uncontrolledState);`

The setter now computes updates based on valueRef.current:

`const nextValue = isSetStateAction(next) ? next(valueRef.current) : next;`

After computing the next value, the ref is updated immediately:

`valueRef.current = nextValue;`

This ensures subsequent functional updates in the same render cycle receive the correct latest value.

### Ref synchronization

Since the ref may be optimistically updated before React commits the actual value, we resync it after each render using a safe insertion/layout effect:

```
useSafeInsertionEffect(() => {
  valueRef.current = value;
});
```

This keeps the ref consistent with the real state value.

### Controlled mode edge case

In controlled mode, the parent may choose not to update the value.
To ensure the ref resynchronizes correctly in that case, a forced re-render is triggered:

```
const [, triggerRerender] = useReducer(() => ({}), {});

...

triggerRerender();
```

## Result

useControlledState now correctly handles multiple functional updates:

```
setValue(prev => prev + 3);
setValue(prev => prev + 3);

// 5 → 8 → 11
```

without stale closure issues.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
