### PR TITLE
docs(core, mobile): fix typos and incorrect descriptions

### DIFF
--- a/docs/core/contributing.md
+++ b/docs/core/contributing.md
@@ -257,7 +257,7 @@ All `react-simplikit` implementations use special rendering functions to verify 
     expect(screen.getByText('Test Content')).toBeInTheDocument();
   });
 
-  it('should hydration mismatch error occured', async () => {
+  it('should hydration mismatch error occurred', async () => {
     // This test code will fail due to a hydration mismatch error.
     await renderSSR(() => (
       <Component>

--- a/docs/core/intro.md
+++ b/docs/core/intro.md
@@ -110,7 +110,7 @@ function Page() {
 
 ## Ensuring Safe Operation in SSR Environments
 
-With the active adoption of SSR environments, poorly written components or hooks can cause errors in SSR environments or hydration mismatches. `react-simplikit` was designed to minimize these issues and guarantees this through 100% test coverage in SSR environments.
+With the active adoption of SSR environments, poorly written components or hooks can cause errors in SSR environments or hydration mismatches. `react-simplikit` was designed to minimize these issues and guarantee this through 100% test coverage in SSR environments.
 
 ## No Dependencies Beyond React
 

--- a/docs/ko/core/contributing.md
+++ b/docs/ko/core/contributing.md
@@ -251,7 +251,7 @@ yarn test:coverage
     expect(screen.getByText('Test Content')).toBeInTheDocument();
   });
 
-  it('should hydration mismatch error occured', async () => {
+  it('should hydration mismatch error occurred', async () => {
     // 이 테스트 코드는 하이드레이션 오류가 발생하여 테스트가 실패해요.
     await renderSSR(() => (
       <Component>

--- a/packages/core/src/components/ImpressionArea/ImpressionArea.tsx
+++ b/packages/core/src/components/ImpressionArea/ImpressionArea.tsx
@@ -5,8 +5,8 @@ import { mergeRefs } from '../../utils/mergeRefs/mergeRefs.ts';
 
 type Element<
   T extends ElementType,
-  InstrinsicElements = T extends keyof React.JSX.IntrinsicElements ? React.JSX.IntrinsicElements[T] : HTMLElement,
-> = InstrinsicElements extends React.ClassAttributes<infer E extends HTMLElement> ? E : HTMLElement;
+  IntrinsicElementsOf = T extends keyof React.JSX.IntrinsicElements ? React.JSX.IntrinsicElements[T] : HTMLElement,
+> = IntrinsicElementsOf extends React.ClassAttributes<infer E extends HTMLElement> ? E : HTMLElement;
 
 type Props<Tag extends ElementType> = React.ComponentPropsWithoutRef<Tag> &
   UseImpressionRefOptions & {

--- a/packages/core/src/hooks/usePrevious/ko/usePrevious.md
+++ b/packages/core/src/hooks/usePrevious/ko/usePrevious.md
@@ -38,6 +38,6 @@ function usePrevious<T>(
 
 ```tsx
 const [count, setCount] = useState(0);
-// previousCount의 초기 값은 `0`이예요
+// previousCount의 초기 값은 `0`이에요
 const previousCount = usePrevious(count);
 ```

--- a/packages/core/src/hooks/usePrevious/usePrevious.ts
+++ b/packages/core/src/hooks/usePrevious/usePrevious.ts
@@ -5,7 +5,7 @@ const strictEquals = <T>(prev: T | undefined, next: T) => prev === next;
 /**
  * @description
  * `usePrevious` is a React hook that returns the previous value of the input state.
- * It preserves the previous value unchanged when re-render occur without state changes.
+ * It preserves the previous value unchanged when re-renders occur without state changes.
  * If the state is an object or requires custom change detection, a `compare` function can be provided.
  * By default, state changes are detected using `prev === next`.
  *

--- a/packages/core/src/hooks/useStorageState/ko/useStorageState.md
+++ b/packages/core/src/hooks/useStorageState/ko/useStorageState.md
@@ -81,7 +81,7 @@ function useStorageState(
       name: 'refreshState',
       type: '() => void',
       required: false,
-      description: '저장소에서 상태를 새롭게 고치는 함수예요.',
+      description: '저장소에서 상태를 다시 가져오는 함수예요.',
     },
   ]"
 />

--- a/packages/core/src/hooks/useStorageState/useStorageState.spec.ts
+++ b/packages/core/src/hooks/useStorageState/useStorageState.spec.ts
@@ -327,7 +327,7 @@ describe('useStorageState', () => {
       expect(result.current[0]).toBe('value from other tab');
     });
 
-    it('should return defaultValue when an error occured while parsing data', async () => {
+    it('should return defaultValue when an error occurred while parsing data', async () => {
       const { result } = await renderHookSSR(() =>
         useStorageState<string>('test-key', { storage: safeLocalStorage, defaultValue: 'default' })
       );

--- a/packages/mobile/src/hooks/useBodyScrollLock/useBodyScrollLock.ts
+++ b/packages/mobile/src/hooks/useBodyScrollLock/useBodyScrollLock.ts
@@ -6,7 +6,7 @@ import { enableBodyScrollLock } from '../../utils/enableBodyScrollLock/index.ts'
 /**
  * Hook to lock body scroll
  *
- * Automatically locks body scroll when mounted,  unlocks when unmounted.
+ * Automatically locks body scroll when mounted, unlocks when unmounted.
  *
  * **Note:** For multiple overlapping modals, use a single lock at the parent level.
  *

--- a/packages/mobile/src/utils/disableBodyScrollLock/ko/disableBodyScrollLock.md
+++ b/packages/mobile/src/utils/disableBodyScrollLock/ko/disableBodyScrollLock.md
@@ -1,6 +1,6 @@
 # disableBodyScrollLock
 
-`disableBodyScrollLock`는 body 스크롤을 잠금 해제하는 유틸리티 함수예요. `enableBodyScrollLock`에 의해 잠겨진 스크롤을 복원하고 저장된 스크롤 위치로 되돌아가요. SSR 환경에서 호출할 때 안전해요 (서버에서는 작동하지 않음). 잠겨 있지 않아도 호출해도 안전해요요.
+`disableBodyScrollLock`는 body 스크롤을 잠금 해제하는 유틸리티 함수예요. `enableBodyScrollLock`에 의해 잠겨진 스크롤을 복원하고 저장된 스크롤 위치로 되돌아가요. SSR 환경에서 호출할 때 안전해요 (서버에서는 작동하지 않음). 잠겨 있지 않아도 호출해도 안전해요.
 
 ## 인터페이스
 

--- a/packages/mobile/src/utils/isAndroid/ko/isAndroid.md
+++ b/packages/mobile/src/utils/isAndroid/ko/isAndroid.md
@@ -21,7 +21,7 @@ function isAndroid(userAgent: string): boolean;
 <Interface
   name=""
   type="boolean"
-  description="기기가 안드로이드에서 실행 중인 경우, 그렇지 않으면 <code>false</code>를 반환해요. 서버에서는 <code>false</code>를 반환해요"
+  description="기기가 안드로이드에서 실행 중이면 <code>true</code>를, 그렇지 않으면 <code>false</code>를 반환해요. 서버에서는 <code>false</code>를 반환해요"
   :nested="[
     {
       required: false,

--- a/packages/mobile/src/utils/isIOS/ko/isIOS.md
+++ b/packages/mobile/src/utils/isIOS/ko/isIOS.md
@@ -24,7 +24,7 @@ function isIOS(userAgent: string): boolean;
 <Interface
   name=""
   type="boolean"
-  description="기기가 iOS 또는 iPadOS에서 실행 중이면 <code>false</code>이 아니면<code>false</code>를 반환해요. 서버에서는 <code>false</code>를 반환해요"
+  description="기기가 iOS 또는 iPadOS에서 실행 중이면 <code>true</code>를, 그렇지 않으면 <code>false</code>를 반환해요. 서버에서는 <code>false</code>를 반환해요"
   :nested="[
     {
       required: false,

--- a/packages/mobile/src/utils/isKeyboardVisible/ko/isKeyboardVisible.md
+++ b/packages/mobile/src/utils/isKeyboardVisible/ko/isKeyboardVisible.md
@@ -15,7 +15,7 @@ function isKeyboardVisible(): boolean;
 <Interface
   name=""
   type="boolean"
-  description="만약 키보드가 보이면, <code>false</code>를 반환해요."
+  description="만약 키보드가 보이면 <code>true</code>를, 그렇지 않으면 <code>false</code>를 반환해요."
 />
 
 ## 예시

--- a/packages/mobile/src/utils/isServer/ko/isServer.md
+++ b/packages/mobile/src/utils/isServer/ko/isServer.md
@@ -15,7 +15,7 @@ function isServer(): boolean;
 <Interface
   name=""
   type="boolean"
-  description="서버 환경 (SSR)에서 실행 중이면 <code>false</code>이고, 그렇지 않으면 <code>true</code>야요."/>
+  description="서버 환경 (SSR)에서 실행 중이면 <code>true</code>를, 그렇지 않으면 <code>false</code>를 반환해요."/>
 
 ## 예시
 

--- a/packages/mobile/src/utils/subscribeKeyboardHeight/subscribeKeyboardHeight.md
+++ b/packages/mobile/src/utils/subscribeKeyboardHeight/subscribeKeyboardHeight.md
@@ -55,7 +55,7 @@ function subscribeKeyboardHeight(
       type: '() => void',
       required: false,
       description:
-        'Unsubscribes all listeners and stops receiving keyboard height updates..',
+        'Unsubscribes all listeners and stops receiving keyboard height updates.',
     },
   ]"
 />


### PR DESCRIPTION
## Summary
- Fix misspelled type parameter `InstrinsicElements` → `IntrinsicElementsOf` in `ImpressionArea.tsx`
- Fix `occured` → `occurred` in test descriptions and contributing docs (3 occurrences)
- Fix grammar `re-render occur` → `re-renders occur` in `usePrevious` JSDoc
- Fix duplicate period in `subscribeKeyboardHeight` doc
- Fix Korean typos: `이예요` → `이에요`, `안전해요요` → `안전해요`
- Fix incorrect return value descriptions in Korean docs for `isKeyboardVisible`, `isIOS`, `isAndroid` (were describing wrong boolean values)

## Test plan
- [x] `yarn run test:type` passes
- [ ] Verify docs render correctly on VitePress