### PR TITLE
refactor(core): replace any types with unknown in useStorageState

### DIFF
--- a/packages/core/src/hooks/useStorageState/useStorageState.spec.ts
+++ b/packages/core/src/hooks/useStorageState/useStorageState.spec.ts
@@ -204,9 +204,9 @@ describe('useStorageState', () => {
     });
 
     it('should work with custom serializer and deserializer', async () => {
-      const serializer = (value: any) =>
+      const serializer = (value: string) =>
         ['string', 'number', 'boolean'].includes(typeof value) ? value : JSON.stringify(value);
-      const deserializer = (value: any) =>
+      const deserializer = (value: string) =>
         /^(\d+)|(true|false)|([^[].*)|([^{].*)$/.test(value) ? value : JSON.parse(value);
 
       const { result } = await renderHookSSR(() => useStorageState('test-key', { storage, serializer, deserializer }));

--- a/packages/core/src/hooks/useStorageState/useStorageState.ts
+++ b/packages/core/src/hooks/useStorageState/useStorageState.ts
@@ -21,7 +21,7 @@ type StorageStateOptionsWithSerializer<T> = StorageStateOptions<T> & {
   deserializer: (value: string) => Serializable<T>;
 };
 
-type SerializableGuard<T extends readonly any[]> = T[0] extends any
+type SerializableGuard<T extends readonly unknown[]> = T[0] extends unknown
   ? T
   : T[0] extends never
     ? 'Received a non-serializable value'
@@ -33,7 +33,7 @@ const emitListeners = () => {
   listeners.forEach(listener => listener());
 };
 
-function isPlainObject(value: unknown): value is Record<PropertyKey, any> {
+function isPlainObject(value: unknown): value is Record<PropertyKey, unknown> {
   if (typeof value !== 'object') {
     return false;
   }
@@ -49,7 +49,7 @@ function isPlainObject(value: unknown): value is Record<PropertyKey, any> {
   return Object.prototype.toString.call(value) === '[object Object]';
 }
 
-const ensureSerializable = <T extends readonly any[]>(value: T): SerializableGuard<T> => {
+const ensureSerializable = <T extends readonly unknown[]>(value: T): SerializableGuard<T> => {
   if (
     value[0] != null &&
     !['string', 'number', 'boolean'].includes(typeof value[0]) &&


### PR DESCRIPTION
## Summary
- Replace `any` with `unknown` in `SerializableGuard`, `isPlainObject`, and `ensureSerializable` type definitions
- Replace `any` with `string` in test serializer/deserializer parameters to match the hook's option types
- Aligns with the project's no-`any` coding standard

## Test plan
- [x] Type check passes (`yarn run test:type`)
- [x] All 48 useStorageState tests pass