### PR TITLE
fix: alias mobile source in vite example to avoid prebuild requirement

### DIFF
--- a/examples/with-vite/vite.config.ts
+++ b/examples/with-vite/vite.config.ts
@@ -1,6 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      // Use source directly so the example app can run without prebuilding workspace packages.
+      '@react-simplikit/mobile': path.resolve(__dirname, '../../packages/mobile/src/index.ts'),
+    },
+  },
 });

--- a/examples/with-vite/vite.config.ts
+++ b/examples/with-vite/vite.config.ts
@@ -1,17 +1,6 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 export default defineConfig({
   plugins: [react()],
-  resolve: {
-    alias: {
-      // Use source directly so the example app can run without prebuilding workspace packages.
-      '@react-simplikit/mobile': path.resolve(__dirname, '../../packages/mobile/src/index.ts'),
-    },
-  },
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "rimraf ./coverage ./node_modules",
     "clean:all": "yarn clean && yarn workspaces foreach -Ap run clean",
-    "example:vite": "yarn workspace with-vite dev",
+    "example:vite": "yarn build && yarn workspace with-vite dev",
     "example:next": "yarn workspace with-nextjs dev",
     "scaffold": "tsx .scripts/index.ts scaffold",
     "changeset": "changeset",


### PR DESCRIPTION
## Overview

Fixes #358

When running `yarn example:vite` in a clean workspace (no prebuilt `dist/`), Vite fails to resolve `@react-simplikit/mobile` because the package's `exports` field points to `dist/index.js`, which doesn't exist yet.

This PR adds a `resolve.alias` to `examples/with-vite/vite.config.ts` that maps `@react-simplikit/mobile` directly to its TypeScript source entry (`packages/mobile/src/index.ts`), so the example dev server works without needing to build workspace packages first.

**Note:** The Next.js example (`with-nextjs`) was not affected — it starts successfully even without a prebuild step.

## Checklist

- [ ] Did you write the test code?
  - N/A — this is a dev tooling fix for the example app config, not a library change
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
  - N/A — no library code changed
- [ ] Did you write the JSDoc?
  - N/A — no new public API