### PR TITLE
fix(plugin): add marketplace.json so the install command actually works

### DIFF
--- a/packages/plugin/.claude-plugin/marketplace.json
+++ b/packages/plugin/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "react-design-philosophy",
+  "owner": { "name": "toss" },
+  "metadata": {
+    "description": "React design philosophy skills for hook review, hook writing, and higher-level API abstraction decisions."
+  },
+  "plugins": [
+    {
+      "name": "react-design-philosophy",
+      "source": "./",
+      "description": "React design philosophy for abstraction design, hook review, and hook writing."
+    }
+  ]
+}

--- a/packages/plugin/.claude-plugin/marketplace.json
+++ b/packages/plugin/.claude-plugin/marketplace.json
@@ -7,8 +7,7 @@
   "plugins": [
     {
       "name": "react-design-philosophy",
-      "source": "./",
-      "description": "React design philosophy for abstraction design, hook review, and hook writing."
+      "source": "./"
     }
   ]
 }

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -5,9 +5,19 @@ React design philosophy plugin for Claude Code. Includes skills for reviewing an
 ## Install
 
 ```bash
-claude plugin install --source git-subdir \
-  --url https://github.com/toss/react-simplikit.git \
-  --path packages/plugin
+# 1. Add this plugin's marketplace (sparse-checkout keeps the clone minimal)
+claude plugin marketplace add https://github.com/toss/react-simplikit \
+  --sparse packages/plugin
+
+# 2. Install the plugin
+claude plugin install react-design-philosophy@react-design-philosophy
+```
+
+To uninstall:
+
+```bash
+claude plugin uninstall react-design-philosophy@react-design-philosophy
+claude plugin marketplace remove react-design-philosophy
 ```
 
 ## Skills


### PR DESCRIPTION
## Summary

After #366 merged, the `react-design-philosophy` plugin is **impossible to install** because it ships only `plugin.json`, not the `marketplace.json` required by `claude plugin`. The README install command also references CLI flags (`--source`, `--url`, `--path`) that don't exist in the current `claude plugin` CLI.

This PR fixes both.

## Evidence of the bug on current main

```bash
$ claude plugin marketplace add /path/to/packages/plugin
✘ Failed to add marketplace: Marketplace file not found at
  packages/plugin/.claude-plugin/marketplace.json

$ claude plugin install --help
Usage: claude plugin install [options] <plugin>
Options:
  -s, --scope <scope>    # (no --source / --url / --path)
```

## Changes

1. **Add `packages/plugin/.claude-plugin/marketplace.json`** — declares a single-plugin marketplace whose `source` points at `"./"` (plugin and marketplace share the same directory)
2. **Rewrite README `## Install` section** — replace the non-existent `--source git-subdir` flags with the real two-step flow

## Verified locally end-to-end

| Step | Command | Result |
|---|---|---|
| 1 | `claude plugin validate .` | ✅ Passed |
| 2 | `claude plugin marketplace add . --scope local` | ✅ Added `react-design-philosophy` |
| 3 | `claude plugin install react-design-philosophy@react-design-philosophy` | ✅ Installed v0.1.0, **enabled** |
| 4 | `claude plugin list` | ✅ Listed |
| 5 | `claude plugin uninstall …` | ✅ Cleanly removed |

## Test plan

- [ ] After merge, run the README command set against the published repo from a fresh directory
- [ ] Confirm `/react-design-principles`, `/react-hook-review`, `/react-hook-writing` are available after install