### PR TITLE
fix(plugin): move marketplace.json to repo root so GitHub install works

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "react-design-philosophy",
-      "source": "./"
+      "source": "./packages/plugin"
     }
   ]
 }

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -7,7 +7,7 @@ React design philosophy plugin for Claude Code. Includes skills for reviewing an
 ```bash
 # 1. Add this plugin's marketplace (sparse-checkout keeps the clone minimal)
 claude plugin marketplace add https://github.com/toss/react-simplikit \
-  --sparse packages/plugin
+  --sparse .claude-plugin packages/plugin
 
 # 2. Install the plugin
 claude plugin install react-design-philosophy@react-design-philosophy


### PR DESCRIPTION
## Summary

Follow-up to #374. The plugin is still **not installable via the documented GitHub URL flow** because `.claude-plugin/marketplace.json` lives under `packages/plugin/`, not at the repo root. `claude plugin marketplace add` always looks for the manifest at `<repo-root>/.claude-plugin/marketplace.json` — `--sparse` only limits checkout scope, not the manifest lookup path.

## Reproduction (on current main)

```bash
$ claude plugin marketplace add https://github.com/toss/react-simplikit \
    --sparse packages/plugin
✘ Failed to add marketplace: Marketplace file not found at
  <tempdir>/.claude-plugin/marketplace.json
```

## Changes

| File | Action |
|---|---|
| `.claude-plugin/marketplace.json` (new at repo root) | Created — points `source: "./packages/plugin"` at the plugin |
| `packages/plugin/.claude-plugin/marketplace.json` | Deleted — moved to root |
| `packages/plugin/README.md` | Updated install command to `--sparse .claude-plugin packages/plugin` |
| `packages/plugin/.claude-plugin/plugin.json` | **Untouched** — plugin identity still lives with the plugin |

## Monorepo pattern

This matches the canonical monorepo marketplace layout:

```
<repo-root>/
├── .claude-plugin/marketplace.json      ← catalog (root)
└── packages/plugin/
    └── .claude-plugin/plugin.json       ← plugin identity (co-located)
```

## Verified locally

| Step | Command | Result |
|---|---|---|
| 1 | `claude plugin validate .` | ✅ Passed |
| 2 | `claude plugin marketplace add <repo-root> --scope local` | ✅ Added |
| 3 | `claude plugin install react-design-philosophy@react-design-philosophy` | ✅ Installed v0.1.0, **enabled** |

(Local path install mirrors the post-clone state, so this proves the real install flow will work once merged.)

## Test plan

- [ ] After merge, run the README command from a fresh directory against the public repo
- [ ] Confirm plugin shows up in `claude plugin list` with status `enabled`