### PR TITLE
feat: add codex plugin setting

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "react-simplikit",
+  "interface": {
+    "displayName": "React Simplikit"
+  },
+  "plugins": [
+    {
+      "name": "react-design-philosophy",
+      "source": {
+        "source": "local",
+        "path": "./packages/plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development"
+    }
+  ]
+}

--- a/packages/plugin/.codex-plugin/plugin.json
+++ b/packages/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "react-design-philosophy",
+  "version": "0.1.0",
+  "description": "React design philosophy for abstraction design, hook review, and hook writing. Covers declarative APIs, lifecycle safety, SSR, state design, effect patterns, TypeScript, and performance.",
+  "author": { "name": "kimyouknow, zztnrudzz13" },
+  "homepage": "https://react-simplikit.slash.page",
+  "repository": "https://github.com/toss/react-simplikit",
+  "license": "MIT",
+  "keywords": ["react", "hooks", "philosophy", "code-review", "api-design", "ssr", "typescript"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "React Design Philosophy",
+    "shortDescription": "React hook design, review, and API abstraction guidance.",
+    "longDescription": "React design philosophy for abstraction design, hook review, and hook writing. Covers declarative APIs, lifecycle safety, SSR, state design, effect patterns, TypeScript, and performance.",
+    "developerName": "Toss",
+    "category": "Development",
+    "capabilities": ["Review", "Write"],
+    "websiteURL": "https://react-simplikit.slash.page",
+    "defaultPrompt": [
+      "Review this hook against React design principles.",
+      "Design a React hook API for this behavior.",
+      "Check whether this abstraction fits React."
+    ]
+  }
+}

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -4,6 +4,8 @@ React design philosophy plugin for Claude Code. Includes skills for reviewing an
 
 ## Install
 
+### Claude Code
+
 ```bash
 # 1. Add this plugin's marketplace (sparse-checkout keeps the clone minimal)
 claude plugin marketplace add https://github.com/toss/react-simplikit \
@@ -13,11 +15,27 @@ claude plugin marketplace add https://github.com/toss/react-simplikit \
 claude plugin install react-design-philosophy@react-design-philosophy
 ```
 
+### Codex
+
+```bash
+codex plugin marketplace add https://github.com/toss/react-simplikit
+```
+
+Then install `React Design Philosophy` from the Codex plugin UI.
+
 To uninstall:
+
+### Claude Code
 
 ```bash
 claude plugin uninstall react-design-philosophy@react-design-philosophy
 claude plugin marketplace remove react-design-philosophy
+```
+
+### Codex
+
+```bash
+codex plugin marketplace remove react-simplikit
 ```
 
 ## Skills


### PR DESCRIPTION
# Overview

## Summary

- Add Codex plugin metadata for the React Design Philosophy plugin.
- Register the plugin in the local agents marketplace so it can be discovered and installed from this repository.
- Include plugin display metadata, prompts, capabilities, category, repository, homepage, and skill entrypoint configuration.

## Test Plan

- Not run; configuration-only change.
- Verified the plugin metadata and marketplace registration files are present.

## Checklist

- [ ] Did you write the test code?
- [ ] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
