### PR TITLE
chore: update code owners to mnxmnz and hyesungoh

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kimyouknow @zztnrudzz13
+* @mnxmnz @hyesungoh

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug Report
 about: Help us improve react-simplikit by reporting a bug
 title: '[BUG] '
 labels: 'bug'
-assignees: 'kimyouknow'
+assignees: 'mnxmnz, hyesungoh'
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -3,7 +3,7 @@ name: Documentation
 about: Help us improve react-simplikit's documentation
 title: '[DOCS] '
 labels: 'documentation'
-assignees: 'kimyouknow'
+assignees: 'mnxmnz, hyesungoh'
 ---
 
 **Location of the documentation**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature Request
 about: Suggest an idea for react-simplikit
 title: '[FEATURE] '
 labels: 'enhancement'
-assignees: 'kimyouknow'
+assignees: 'mnxmnz, hyesungoh'
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -3,7 +3,7 @@ name: Other Issue
 about: Create a report for issues that don't fit the above templates
 title: ''
 labels: 'question'
-assignees: 'kimyouknow'
+assignees: 'mnxmnz, hyesungoh'
 ---
 
 **Describe the issue**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,5 +109,5 @@ jobs:
           title: 'docs(${{ needs.get-diffs.outputs.result }}): auto-generated docs'
           body: 'This PR includes documentation updates for: ${{ needs.get-diffs.outputs.result }}'
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          reviewers: kimyouknow,zztnrudzz13
+          reviewers: mnxmnz,hyesungoh
           commit-message: 'Generate docs for ${{ needs.get-diffs.outputs.result }}'


### PR DESCRIPTION
# Overview

Update code owners from `@kimyouknow`, `@zztnrudzz13` to `@mnxmnz`, `@hyesungoh`.

Changed files:

- `.github/CODEOWNERS` — repository-wide owners
- `.github/ISSUE_TEMPLATE/{bug_report,documentation,feature_request,other}.md` — default issue assignees
- `.github/workflows/release.yml` — reviewers for the auto-generated docs PR

Left unchanged on purpose:

- `packages/*/CHANGELOG.md` — `Thanks @kimyouknow` lines are historical contribution records
- `packages/plugin/.{claude,codex}-plugin/plugin.json` — the `author` field denotes original authorship, not ownership

> **Note:** For CODEOWNERS to take effect, `@mnxmnz` and `@hyesungoh` need write access to this repository. GitHub silently ignores CODEOWNERS entries for users without it.

## Checklist

- [ ] Did you write the test code? — N/A (repository configuration only)
- [ ] Have you run `yarn run fix` to format and lint the code and docs? — N/A (no source changes)
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line? — N/A (no source changes)
- [ ] Did you write the JSDoc? — N/A (no public API changes)
