### PR TITLE
test: enforce 100% coverage thresholds with corrected denominators

### DIFF
--- a/packages/core/src/components/Separated/Separated.tsx
+++ b/packages/core/src/components/Separated/Separated.tsx
@@ -38,8 +38,9 @@ export function Separated({ children, by: separator }: Props) {
 
   return (
     <>
+      {/* Children.toArray always assigns a key, so no positional fallback is needed */}
       {childrenArray.map((child, i, { length }) => (
-        <Fragment key={child.key ?? i}>
+        <Fragment key={child.key}>
           {child}
           {i + 1 !== length && separator}
         </Fragment>

--- a/packages/core/src/hooks/useImpressionRef/useImpressionRef.spec.ts
+++ b/packages/core/src/hooks/useImpressionRef/useImpressionRef.spec.ts
@@ -88,6 +88,8 @@ describe('useImpressionRef', () => {
     await act(async () => {
       observerCallback([{ isIntersecting: true, intersectionRatio: 0.6 }], null);
       vi.runAllTimers();
+      observerCallback([{ isIntersecting: false, intersectionRatio: 0 }], null);
+      vi.runAllTimers();
     });
 
     expect(mockOnImpressionStart).not.toHaveBeenCalled();

--- a/packages/core/src/hooks/useLongPress/useLongPress.spec.tsx
+++ b/packages/core/src/hooks/useLongPress/useLongPress.spec.tsx
@@ -45,6 +45,35 @@ describe('useLongPress', () => {
     expect(onLongPress).toHaveBeenCalledTimes(1);
   });
 
+  it('should handle press and release without onClick and onLongPressEnd options', async () => {
+    const onLongPress = vi.fn();
+    const TestComponent = () => {
+      const longPressHandlers = useLongPress(onLongPress);
+      return (
+        <button data-testid="test-button" {...longPressHandlers}>
+          Press me
+        </button>
+      );
+    };
+
+    render(<TestComponent />);
+    const button = screen.getByTestId('test-button');
+
+    // Short press falls back to the noop onClick
+    fireEvent.mouseDown(button);
+    fireEvent.mouseUp(button);
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    // Completed long press falls back to the noop onLongPressEnd
+    fireEvent.mouseDown(button);
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    fireEvent.mouseUp(button);
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
   it('should respect custom delay timing', async () => {
     const onLongPress = vi.fn();
     const TestComponent = () => {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
       reporter: ['text', 'json'],
       extension: ['.ts', '.tsx'],
       include: ['src/**/*.ts?(x)'],
-      exclude: ['src/**/index.ts', 'src/**/*.spec.ts?(x)'],
+      exclude: ['src/**/index.ts', 'src/**/*.{spec,test}.ts?(x)', 'src/_internal/test-utils/**'],
+      thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 },
     },
   },
 });

--- a/packages/mobile/src/hooks/useNetworkStatus/useNetworkStatus.spec.ts
+++ b/packages/mobile/src/hooks/useNetworkStatus/useNetworkStatus.spec.ts
@@ -5,6 +5,15 @@ import { renderHookSSR } from '../../../test/renderHookSSR.tsx';
 
 import { useNetworkStatus } from './useNetworkStatus.ts';
 
+const serverEnvironmentFlag = vi.hoisted(() => ({ current: false }));
+
+vi.mock('../../utils/isServer/index.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../utils/isServer/index.ts')>();
+  return {
+    isServer: () => serverEnvironmentFlag.current || original.isServer(),
+  };
+});
+
 describe('useNetworkStatus', () => {
   it('is safe on server side rendering', () => {
     const result = renderHookSSR.serverOnly(() => useNetworkStatus());
@@ -24,6 +33,7 @@ describe('useNetworkStatus', () => {
     };
 
     beforeEach(() => {
+      serverEnvironmentFlag.current = false;
       mockConnection = {
         effectiveType: '4g',
         type: 'wifi',
@@ -115,6 +125,28 @@ describe('useNetworkStatus', () => {
       const { result } = renderHook(() => useNetworkStatus());
 
       expect(result.current).toEqual({});
+    });
+
+    it('should return empty object when accessing the connection API throws', () => {
+      Object.defineProperty(navigator, 'connection', {
+        configurable: true,
+        get() {
+          throw new Error('connection access blocked');
+        },
+      });
+
+      const { result } = renderHook(() => useNetworkStatus());
+
+      expect(result.current).toEqual({});
+    });
+
+    it('should return empty object without subscribing in a server-like environment', () => {
+      serverEnvironmentFlag.current = true;
+
+      const { result } = renderHook(() => useNetworkStatus());
+
+      expect(result.current).toEqual({});
+      expect(mockConnection.addEventListener).not.toHaveBeenCalled();
     });
 
     it('should handle undefined values gracefully', () => {

--- a/packages/mobile/src/hooks/useSafeAreaInset/useSafeAreaInset.test.ts
+++ b/packages/mobile/src/hooks/useSafeAreaInset/useSafeAreaInset.test.ts
@@ -3,11 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useSafeAreaInset } from './useSafeAreaInset.ts';
 
+const serverEnvironmentFlag = vi.hoisted(() => ({ current: false }));
+
+vi.mock('../../utils/isServer/index.ts', async importOriginal => {
+  const original = await importOriginal<typeof import('../../utils/isServer/index.ts')>();
+  return {
+    isServer: () => serverEnvironmentFlag.current || original.isServer(),
+  };
+});
+
 describe('useSafeAreaInset', () => {
   let mockGetComputedStyle: ReturnType<typeof vi.fn>;
   let createdElements: HTMLElement[] = [];
 
   beforeEach(() => {
+    serverEnvironmentFlag.current = false;
     createdElements = [];
 
     // Mock document.createElement
@@ -51,6 +61,22 @@ describe('useSafeAreaInset', () => {
       left: 0,
       right: 0,
     });
+  });
+
+  it('should return zero insets without subscribing to resize in a server-like environment', () => {
+    serverEnvironmentFlag.current = true;
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+    const { result } = renderHook(() => useSafeAreaInset());
+
+    expect(result.current).toEqual({
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    });
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('resize', expect.any(Function));
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('orientationchange', expect.any(Function));
   });
 
   it('should register resize and orientationchange event listeners on mount', () => {

--- a/packages/mobile/src/hooks/useScrollDirection/useScrollDirection.test.ts
+++ b/packages/mobile/src/hooks/useScrollDirection/useScrollDirection.test.ts
@@ -1,6 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { renderHookSSR } from '../../../test/renderHookSSR.tsx';
+
 import { useScrollDirection } from './useScrollDirection.ts';
 
 describe('useScrollDirection', () => {
@@ -26,6 +28,42 @@ describe('useScrollDirection', () => {
     expect(result.current).toEqual({
       direction: null,
       position: 0,
+    });
+  });
+
+  it('is safe on server side rendering', () => {
+    const result = renderHookSSR.serverOnly(() => useScrollDirection());
+
+    expect(result.current).toEqual({
+      direction: null,
+      position: 0,
+    });
+  });
+
+  it('should ignore scroll events that arrive while the throttle timer is pending', async () => {
+    const { result } = renderHook(() => useScrollDirection());
+
+    await act(async () => {
+      Object.defineProperty(window, 'scrollY', { value: 100 });
+      window.dispatchEvent(new Event('scroll'));
+      // Second scroll before the 50ms throttle timer expires
+      Object.defineProperty(window, 'scrollY', { value: 999 });
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current).toEqual({
+      direction: 'down',
+      position: 100,
+    });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    // The throttled second event is dropped, not deferred
+    expect(result.current).toEqual({
+      direction: 'down',
+      position: 100,
     });
   });
 

--- a/packages/mobile/src/hooks/useVisualViewport/useVisualViewport.test.ts
+++ b/packages/mobile/src/hooks/useVisualViewport/useVisualViewport.test.ts
@@ -1,6 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { renderHookSSR } from '../../../test/renderHookSSR.tsx';
+
 import { useVisualViewport } from './useVisualViewport.ts';
 
 describe('useVisualViewport', () => {
@@ -158,6 +160,31 @@ describe('useVisualViewport', () => {
     });
 
     const { result } = renderHook(() => useVisualViewport());
+
+    expect(result.current.viewport).toBeNull();
+  });
+
+  it('is safe on server side rendering', () => {
+    const result = renderHookSSR.serverOnly(() => useVisualViewport());
+
+    expect(result.current.viewport).toBeNull();
+  });
+
+  it('should return null when visualViewport disappears before an update', async () => {
+    const { result } = renderHook(() => useVisualViewport());
+
+    const resizeHandler = mockVisualViewport.addEventListener.mock.calls.find(([event]) => event === 'resize')?.[1];
+
+    Object.defineProperty(window, 'visualViewport', {
+      writable: true,
+      configurable: true,
+      value: undefined,
+    });
+
+    await act(async () => {
+      resizeHandler?.();
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
 
     expect(result.current.viewport).toBeNull();
   });

--- a/packages/mobile/src/utils/isAndroid/isAndroid.test.ts
+++ b/packages/mobile/src/utils/isAndroid/isAndroid.test.ts
@@ -22,4 +22,19 @@ describe('isAndroid', () => {
   it('should return false for Mac browser', () => {
     expect(isAndroid('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/537.36')).toBe(false);
   });
+
+  it('should fall back to navigator.userAgent when no argument is given', () => {
+    const originalUserAgent = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) Chrome/126',
+      configurable: true,
+    });
+
+    expect(isAndroid()).toBe(true);
+
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+  });
 });

--- a/packages/mobile/src/utils/isIOS/isIOS.test.ts
+++ b/packages/mobile/src/utils/isIOS/isIOS.test.ts
@@ -80,4 +80,19 @@ describe('isIOS', () => {
 
     expect(isIOS('Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120')).toBe(false);
   });
+
+  it('should fall back to navigator.userAgent when no argument is given', () => {
+    const originalUserAgent = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      configurable: true,
+    });
+
+    expect(isIOS()).toBe(true);
+
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+  });
 });

--- a/packages/mobile/vitest.config.ts
+++ b/packages/mobile/vitest.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
       reporter: ['text', 'json'],
       extension: ['.ts', '.tsx'],
       include: ['src/**/*.ts?(x)'],
-      exclude: ['src/**/index.ts', 'src/**/*.spec.ts?(x)'],
+      exclude: ['src/**/index.ts', 'src/**/*.{spec,test}.ts?(x)', 'src/test/**'],
+      thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 },
     },
   },
 });


### PR DESCRIPTION
# Overview

Closes #391

Makes the "100% coverage" promise real: fixes what coverage measures, closes the actual gaps, then turns on enforcement. Landed in that order (issue #391: "Land 3 before 1") so the threshold is verified against the correct denominator in this same PR.

## Changes

### 1. Correct coverage denominators (both `vitest.config.ts`)

- `exclude` extended from `*.spec` to `*.{spec,test}` — mobile's 32 `.test.ts` / `.ssr.test.ts` files were instrumented **as source**, so mobile's numbers were measured against the wrong denominator.
- Test helper directories excluded: `core/src/_internal/test-utils/**`, `mobile/src/test/**`. They are test infrastructure, not shipped code (`renderHookSSR.tsx` sat at 59% and would have made a 100% threshold unreachable without testing test utils).

### 2. Close the real gaps (8 files were below 100%)

| File | Was | Uncovered |
| --- | --- | --- |
| core `Separated.tsx` | 75% branch | `child.key ?? i` fallback — unreachable: `Children.toArray` always assigns keys. Removed the dead fallback instead of ignoring it (behavior identical, no observable change). |
| core `useImpressionRef.ts` | 80% funcs | default no-op `onImpressionEnd` never invoked → default-options test now exercises the end transition |
| mobile `useNetworkStatus.ts` | 90.9% | `isServer` guard inside the effect + the `catch` around `navigator.connection` access |
| mobile `useSafeAreaInset.ts` | 91.6% | `isServer` guard inside the effect |
| mobile `useScrollDirection.ts` | 96.1% | throttle-window early return — the existing throttle test ran `vi.runAllTimers()` between scrolls, so the timer was always expired and the guard never fired; also the `isServer` ternaries in state init |
| mobile `useVisualViewport.ts` | 86.7% branch | server-side initial render + `visualViewport` disappearing between mount and update |
| mobile `isAndroid.ts` / `isIOS.ts` | 75% / 85.7% branch | `userAgent ?? navigator.userAgent` fallback — never called without an argument |

Why the `isServer()` branches were uncovered everywhere: the `.ssr.test.ts` files run under `@vitest-environment node` and only assert that the module can be imported — they never render the hooks. Server-path coverage now comes from `renderHookSSR.serverOnly` (real `isServer` under stubbed globals) where possible, and from a module mock that defers to the real `isServer` by default for the two effect-level guards that can't run during `renderToString`.

### 3. Enforce (both `vitest.config.ts`)

```ts
thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 }
```

Any future coverage regression fails `yarn test:coverage` locally and in CI (`verify-test` and the `spec (node 24)` job run it since #393).

## Verification

- `yarn test:coverage`: core **100/100/100/100** (321 tests), mobile **100/100/100/100** (191 tests), exit 0 with thresholds active.
- Gate mutation check: temporarily `it.skip`-ing one new test dropped branch coverage and `test:coverage` exited 1 — the threshold actually fails, not just reports. Reverted.
- `yarn test:type` clean; lint has 0 errors (6 pre-existing `no-explicit-any` warnings in untouched `useStorageState` are left out of scope).

No changeset: config/test-only change; the `Separated` edit removes an unreachable expression with no observable behavior difference.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc? (N/A — no API change)
