### PR TITLE
docs(mobile): sync README examples and utility names with the actual API

### DIFF
--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -61,18 +61,20 @@ function SearchInput() {
 import { useAvoidKeyboard, useBodyScrollLock } from '@react-simplikit/mobile';
 
 function ChatInput() {
-  const { ref, style } = useAvoidKeyboard();
+  const { style } = useAvoidKeyboard();
 
   return (
-    <div ref={ref} style={style}>
+    <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, ...style }}>
       <input type="text" placeholder="메시지를 입력하세요..." />
     </div>
   );
 }
 
-function Modal({ isOpen }) {
-  useBodyScrollLock(isOpen);
-  // ...
+// `useBodyScrollLock`은 컴포넌트가 마운트될 때 body 스크롤을 잠그고,
+// 언마운트될 때 자동으로 해제해요. 모달이 열려 있는 동안에만 렌더링하세요.
+function BodyScrollLock() {
+  useBodyScrollLock();
+  return null;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,18 +61,20 @@ function SearchInput() {
 import { useAvoidKeyboard, useBodyScrollLock } from '@react-simplikit/mobile';
 
 function ChatInput() {
-  const { ref, style } = useAvoidKeyboard();
+  const { style } = useAvoidKeyboard();
 
   return (
-    <div ref={ref} style={style}>
+    <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, ...style }}>
       <input type="text" placeholder="Type a message..." />
     </div>
   );
 }
 
-function Modal({ isOpen }) {
-  useBodyScrollLock(isOpen);
-  // ...
+// `useBodyScrollLock` locks body scroll while the component is mounted,
+// and unlocks it automatically on unmount. Render this only while the modal is open.
+function BodyScrollLock() {
+  useBodyScrollLock();
+  return null;
 }
 ```
 

--- a/packages/mobile/README-ko_kr.md
+++ b/packages/mobile/README-ko_kr.md
@@ -45,10 +45,10 @@ pnpm add @react-simplikit/mobile
 import { useAvoidKeyboard } from '@react-simplikit/mobile';
 
 function ChatInput() {
-  const { ref, style } = useAvoidKeyboard();
+  const { style } = useAvoidKeyboard();
 
   return (
-    <div ref={ref} style={style}>
+    <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, ...style }}>
       <input type="text" placeholder="메시지를 입력하세요..." />
     </div>
   );
@@ -57,14 +57,23 @@ function ChatInput() {
 
 ### Body Scroll Lock
 
+`useBodyScrollLock`은 컴포넌트가 마운트될 때 body 스크롤을 잠그고, 언마운트될 때 자동으로 해제해요. 잠그는 시점을 제어하려면 이 훅을 호출하는 컴포넌트를 조건부로 렌더링하세요.
+
 ```tsx
 import { useBodyScrollLock } from '@react-simplikit/mobile';
 
-function Modal({ isOpen, children }) {
-  useBodyScrollLock(isOpen);
+function BodyScrollLock() {
+  useBodyScrollLock();
+  return null;
+}
 
-  if (!isOpen) return null;
-  return <div className="modal">{children}</div>;
+function ModalContainer({ isOpen, children }) {
+  return (
+    <>
+      {isOpen && <BodyScrollLock />}
+      {isOpen && <div className="modal">{children}</div>}
+    </>
+  );
 }
 ```
 
@@ -74,7 +83,12 @@ function Modal({ isOpen, children }) {
 import { useVisualViewport } from '@react-simplikit/mobile';
 
 function Component() {
-  const viewport = useVisualViewport();
+  const { viewport } = useVisualViewport();
+
+  // viewport 속성에 접근하기 전에 항상 null 체크를 해야 해요
+  if (!viewport) {
+    return null;
+  }
 
   return (
     <div style={{ height: viewport.height }}>
@@ -99,13 +113,13 @@ function Component() {
 
 ### Utilities
 
-| Utility               | 설명                      |
-| --------------------- | ------------------------- |
-| `bodyScrollLock`      | 명령형 스크롤 잠금 제어   |
-| `getSafeArea`         | safe area insets 가져오기 |
-| `getKeyboardHeight`   | 키보드 높이 추정          |
-| `isIOS` / `isAndroid` | 기기 감지                 |
-| `isServer`            | SSR 환경 체크             |
+| Utility                                          | 설명                      |
+| ------------------------------------------------ | ------------------------- |
+| `enableBodyScrollLock` / `disableBodyScrollLock` | 명령형 스크롤 잠금 제어   |
+| `getSafeAreaInset`                               | safe area insets 가져오기 |
+| `getKeyboardHeight`                              | 키보드 높이 추정          |
+| `isIOS` / `isAndroid`                            | 기기 감지                 |
+| `isServer`                                       | SSR 환경 체크             |
 
 ## 브라우저 지원
 

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -45,10 +45,10 @@ pnpm add @react-simplikit/mobile
 import { useAvoidKeyboard } from '@react-simplikit/mobile';
 
 function ChatInput() {
-  const { ref, style } = useAvoidKeyboard();
+  const { style } = useAvoidKeyboard();
 
   return (
-    <div ref={ref} style={style}>
+    <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, ...style }}>
       <input type="text" placeholder="Type a message..." />
     </div>
   );
@@ -57,14 +57,23 @@ function ChatInput() {
 
 ### Body Scroll Lock
 
+`useBodyScrollLock` locks body scroll while the component is mounted, and unlocks it automatically on unmount. To control when the lock applies, conditionally render a component that calls it.
+
 ```tsx
 import { useBodyScrollLock } from '@react-simplikit/mobile';
 
-function Modal({ isOpen, children }) {
-  useBodyScrollLock(isOpen);
+function BodyScrollLock() {
+  useBodyScrollLock();
+  return null;
+}
 
-  if (!isOpen) return null;
-  return <div className="modal">{children}</div>;
+function ModalContainer({ isOpen, children }) {
+  return (
+    <>
+      {isOpen && <BodyScrollLock />}
+      {isOpen && <div className="modal">{children}</div>}
+    </>
+  );
 }
 ```
 
@@ -74,7 +83,12 @@ function Modal({ isOpen, children }) {
 import { useVisualViewport } from '@react-simplikit/mobile';
 
 function Component() {
-  const viewport = useVisualViewport();
+  const { viewport } = useVisualViewport();
+
+  // Always check for null first
+  if (!viewport) {
+    return null;
+  }
 
   return (
     <div style={{ height: viewport.height }}>
@@ -99,13 +113,13 @@ function Component() {
 
 ### Utilities
 
-| Utility               | Description                    |
-| --------------------- | ------------------------------ |
-| `bodyScrollLock`      | Imperative scroll lock control |
-| `getSafeArea`         | Get safe area insets           |
-| `getKeyboardHeight`   | Estimate keyboard height       |
-| `isIOS` / `isAndroid` | Device detection               |
-| `isServer`            | SSR environment check          |
+| Utility                                          | Description                    |
+| ------------------------------------------------ | ------------------------------ |
+| `enableBodyScrollLock` / `disableBodyScrollLock` | Imperative scroll lock control |
+| `getSafeAreaInset`                               | Get safe area insets           |
+| `getKeyboardHeight`                              | Estimate keyboard height       |
+| `isIOS` / `isAndroid`                            | Device detection               |
+| `isServer`                                       | SSR environment check          |
 
 ## Browser Support
 


### PR DESCRIPTION
# Overview

Closes #398.

`packages/mobile/README.md` had drifted from the package's actual API in two ways.

All three Quick Start examples failed to compile. `useAvoidKeyboard` was destructured for a `ref` it never returns, `useBodyScrollLock` was called with an argument it does not accept, and `useVisualViewport`'s wrapped return value was read as if it were the state itself. Reproduced with `tsc --noEmit` in `packages/mobile` as TS2339, TS2554 and TS2339; the corrected examples compile with no errors under the same check.

The Utilities table also listed `bodyScrollLock` and `getSafeArea`, neither of which is exported. The real names are `enableBodyScrollLock` / `disableBodyScrollLock` and `getSafeAreaInset`.

Every replacement follows the JSDoc `@example` of the hook it documents. The `useBodyScrollLock` example needed a structural rewrite: simply dropping the argument would have left an example that locks the body whenever the component is mounted. It now uses the conditional-render pattern the hook's own JSDoc prescribes.

Scope note: the two tables are also missing rows (`useKeyboardHeight`, `useSafeAreaInset`, `isKeyboardVisible`, `subscribeKeyboardHeight`), and `useSafeAreaInset` is absent from `docs/mobile/intro.md` as well; the omissions are left out of this PR and noted in #398.

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
