### PR TITLE
fix(ci): push release tags after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,12 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
 
+      # changeset publish creates tags locally but never pushes them.
+      # --tags, not --follow-tags: changesets creates lightweight tags.
+      - name: Push tags
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: git push origin --tags
+
   get-diffs:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
# Overview

Closes #392

`changeset publish` creates release tags locally but never pushes them. Since #316 moved publishing out of `changesets/action` into a standalone `run:` step, nothing pushes tags — the last pushed tag is `v0.0.46` while `packages/core` is at `0.0.51`, so five releases are untagged (`@react-simplikit/mobile` tags are missing entirely).

This adds a `Push tags` step right after `Publish to npm`, gated on the same `hasChangesets == 'false'` condition.

Notes:

- `--tags`, not `--follow-tags` — changesets creates lightweight tags, and `--follow-tags` only pushes annotated ones.
- Safe on no-publish runs: `actions/checkout` doesn't fetch existing tags, so when nothing publishes there are no local tags and the push is a no-op.
- Tag pushes don't re-trigger this workflow (it filters on `branches: main`), and `GITHUB_TOKEN` pushes don't trigger new workflow runs anyway.
- New tags will use the changesets format (`react-simplikit@0.0.52`), not the old `v*` scheme. Backfilling the five missing tags is a manual follow-up.

## Checklist

- [ ] Did you write the test code? — N/A, CI workflow only
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line? — N/A, no source changes
- [ ] Did you write the JSDoc? — N/A, no source changes
