### PR TITLE
chore(ci): auto-assign PR author as assignee

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,0 +1,20 @@
+name: Auto Assign Author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr edit "$PR" --add-assignee "$AUTHOR"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
# Overview

Automatically assigns the PR author as an assignee when a PR is opened or reopened.

- Uses `pull_request_target` so the `GITHUB_TOKEN` keeps `pull-requests: write` permission on PRs from forks (with the plain `pull_request` event, fork PRs get a read-only token and the assignment fails). External contributors are assignable because the PR author is always a valid assignee.
- Safe usage of `pull_request_target`: the workflow never checks out or executes PR code — it only reads event metadata, and `AUTHOR` is passed via `env` instead of inline `${{ }}` interpolation, so there is no script injection surface.
- Skips bot-authored PRs (e.g. dependabot): `gh pr edit --add-assignee` cannot resolve bot accounts as users, which would fail the job on every dependabot PR.

Note: since `pull_request_target` runs the workflow definition from the base branch, this takes effect for PRs opened after this is merged (it will not trigger on this PR itself).

## Checklist

- [ ] Did you write the test code?
- [ ] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
