### PR TITLE
fix(useThrottledCallback): invoke the callback when the first value is false

### DIFF
--- a/.changeset/lucky-pugs-repeat.md
+++ b/.changeset/lucky-pugs-repeat.md
@@ -1,0 +1,7 @@
+---
+'react-simplikit': patch
+---
+
+fix(useThrottledCallback): invoke the callback when the first value is `false`
+
+The hook skips redundant invocations by comparing the incoming value against the last one it forwarded, but that comparison was seeded with `false`. Because the hook takes no initial value from the caller, a first call of `false` looked redundant and was dropped — so consumers whose state starts as `true` lost the transition back to `false`. The comparison now starts from a sentinel, so the first call is always forwarded regardless of its value.

--- a/packages/core/src/hooks/useThrottledCallback/useThrottledCallback.spec.ts
+++ b/packages/core/src/hooks/useThrottledCallback/useThrottledCallback.spec.ts
@@ -97,6 +97,29 @@ describe('useThrottledCallback', () => {
     expect(onChange).toBeCalledTimes(1);
   });
 
+  it('should invoke the callback when the first value is false', () => {
+    const onChange = vi.fn();
+    const { result } = renderHookSSR(() => useThrottledCallback({ onChange, timeThreshold: 100 }));
+
+    result.current(false);
+
+    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toBeCalledWith(false);
+  });
+
+  it('should still skip a repeated false after the first one', () => {
+    const onChange = vi.fn();
+    const { result } = renderHookSSR(() => useThrottledCallback({ onChange, timeThreshold: 100 }));
+
+    result.current(false);
+    vi.advanceTimersByTime(100);
+    expect(onChange).toBeCalledTimes(1);
+
+    result.current(false);
+    vi.advanceTimersByTime(100);
+    expect(onChange).toBeCalledTimes(1);
+  });
+
   it('should handle value toggling', () => {
     const onChange = vi.fn();
     const { result } = renderHookSSR(() => useThrottledCallback({ onChange, timeThreshold: 100 }));

--- a/packages/core/src/hooks/useThrottledCallback/useThrottledCallback.ts
+++ b/packages/core/src/hooks/useThrottledCallback/useThrottledCallback.ts
@@ -9,6 +9,15 @@ type ThrottleOptions = {
 };
 
 /**
+ * Marks that no value has been forwarded to `onChange` yet.
+ *
+ * The hook skips redundant invocations by comparing against the last forwarded value, but it
+ * receives no initial value from the caller. Seeding that comparison with `false` would treat the
+ * first `false` as redundant and swallow it, so an unreachable sentinel is used instead.
+ */
+const NOT_INVOKED = Symbol('NOT_INVOKED');
+
+/**
  * @description
  * `useThrottledCallback` is a React hook that returns a throttled version of the provided callback function.
  * The throttled callback will only be invoked at most once per specified interval.
@@ -38,7 +47,10 @@ export function useThrottledCallback({
   timeThreshold: number;
 }) {
   const handleChange = usePreservedCallback(onChange);
-  const ref = useRef({ value: false, clearPreviousThrottle: () => {} });
+  const ref = useRef<{ value: boolean | typeof NOT_INVOKED; clearPreviousThrottle: () => void }>({
+    value: NOT_INVOKED,
+    clearPreviousThrottle: () => {},
+  });
 
   useEffect(function cleanupThrottleOnUnmount() {
     const current = ref.current;


### PR DESCRIPTION
# Overview

`useThrottledCallback` drops the very first call when the value is `false`.

The hook skips redundant invocations by comparing the incoming value against the last one it forwarded to `onChange`. That comparison is seeded with `false`:

```ts
const ref = useRef({ value: false, clearPreviousThrottle: () => {} });
...
if (nextValue === ref.current.value) {
  return;
}
```

Since the hook takes no initial value from the caller, a first call of `false` matches the seed and returns early, so `onChange` never fires.

```tsx
const onChange = vi.fn();
const { result } = renderHookSSR(() => useThrottledCallback({ onChange, timeThreshold: 100 }));

result.current(false);
// onChange is never called

result.current(true);
// works. only the first `false` is lost
```

This matters for consumers whose state does not start at `false`. If a panel is open by default, the first close emits `false`, and that transition is silently dropped with no way to tell the hook the state started as `true`.

`useDebouncedCallback` has the same seed. I left it alone here because #267 is already changing that line. Its generic rewrite switches the seed to `null`, which fixes this case as a side effect, though a narrower version of the problem survives there: a first call of `null` would still be dropped.

## Changes

- Seed the comparison with a module-level sentinel instead of `false`, so the first call is forwarded regardless of its value. The dedup comparison itself is unchanged, so repeated values are still skipped.
- Add two tests: one for the first `false`, one asserting a repeated `false` is still skipped so the dedup behavior stays pinned.

A `Symbol` is used rather than `null` or `undefined` because it cannot collide with a caller-supplied value if this hook later becomes generic, as `useDebouncedCallback` is doing in #267.

Existing tests all start with `result.current(true)`, which is why this was not caught. The early-return branch is already covered by the repeated-`true` cases, so branch coverage was 100% while the first-call-`false` path was never exercised.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
