### PR TITLE
docs(core): sync Quick Start examples with the actual useDebounce API

### DIFF
--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -38,22 +38,31 @@ npm install @react-simplikit/mobile
 ### react-simplikit
 
 ```tsx
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
 
 function SearchInput() {
   const [query, setQuery] = useState('');
-  const debouncedQuery = useDebounce(query, 300);
 
-  useEffect(() => {
-    if (debouncedQuery) {
-      searchAPI(debouncedQuery);
-    }
-  }, [debouncedQuery]);
+  const debouncedSearch = useDebounce((value: string) => {
+    // 실제 API 호출
+    searchAPI(value);
+  }, 300);
 
-  return <input value={query} onChange={e => setQuery(e.target.value)} />;
+  return (
+    <input
+      value={query}
+      onChange={e => {
+        setQuery(e.target.value);
+        debouncedSearch(e.target.value);
+      }}
+      placeholder="검색어를 입력하세요"
+    />
+  );
 }
 ```
+
+디바운스된 함수는 `.cancel()` 메서드를 제공하고, 컴포넌트가 언마운트되면 대기 중인 호출을 자동으로 취소해요.
 
 ### @react-simplikit/mobile
 

--- a/README.md
+++ b/README.md
@@ -38,22 +38,31 @@ npm install @react-simplikit/mobile
 ### react-simplikit
 
 ```tsx
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
 
 function SearchInput() {
   const [query, setQuery] = useState('');
-  const debouncedQuery = useDebounce(query, 300);
 
-  useEffect(() => {
-    if (debouncedQuery) {
-      searchAPI(debouncedQuery);
-    }
-  }, [debouncedQuery]);
+  const debouncedSearch = useDebounce((value: string) => {
+    // Actual API call
+    searchAPI(value);
+  }, 300);
 
-  return <input value={query} onChange={e => setQuery(e.target.value)} />;
+  return (
+    <input
+      value={query}
+      onChange={e => {
+        setQuery(e.target.value);
+        debouncedSearch(e.target.value);
+      }}
+      placeholder="Enter search term"
+    />
+  );
 }
 ```
+
+The debounced function exposes `.cancel()`, and pending calls are cancelled automatically when the component unmounts.
 
 ### @react-simplikit/mobile
 

--- a/packages/core/README-ko_kr.md
+++ b/packages/core/README-ko_kr.md
@@ -69,22 +69,31 @@ pnpm add react-simplikit
 ## 빠른 시작
 
 ```tsx
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
 
 function SearchInput() {
   const [query, setQuery] = useState('');
-  const debouncedQuery = useDebounce(query, 300);
 
-  useEffect(() => {
-    if (debouncedQuery) {
-      searchAPI(debouncedQuery);
-    }
-  }, [debouncedQuery]);
+  const debouncedSearch = useDebounce((value: string) => {
+    // 실제 API 호출
+    searchAPI(value);
+  }, 300);
 
-  return <input value={query} onChange={e => setQuery(e.target.value)} />;
+  return (
+    <input
+      value={query}
+      onChange={e => {
+        setQuery(e.target.value);
+        debouncedSearch(e.target.value);
+      }}
+      placeholder="검색어를 입력하세요"
+    />
+  );
 }
 ```
+
+디바운스된 함수는 `.cancel()` 메서드를 제공하고, 컴포넌트가 언마운트되면 대기 중인 호출을 자동으로 취소해요.
 
 ## 포함된 기능
 
@@ -93,8 +102,8 @@ function SearchInput() {
 | Hook                      | 설명                                                  |
 | ------------------------- | ----------------------------------------------------- |
 | `useBooleanState`         | boolean 상태를 핸들러와 함께 관리                     |
-| `useDebounce`             | 값을 디바운스                                         |
-| `useDebouncedCallback`    | 콜백 함수를 디바운스                                  |
+| `useDebounce`             | 콜백 함수를 디바운스                                  |
+| `useDebouncedCallback`    | 옵션 객체로 `onChange` 콜백을 디바운스                |
 | `useInterval`             | 선언적으로 인터벌 설정                                |
 | `useIntersectionObserver` | 요소 가시성 관찰                                      |
 | `usePreservedCallback`    | 안정적인 콜백 참조                                    |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -69,37 +69,46 @@ pnpm add react-simplikit
 ## Quick Start
 
 ```tsx
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
 
 function SearchInput() {
   const [query, setQuery] = useState('');
-  const debouncedQuery = useDebounce(query, 300);
 
-  useEffect(() => {
-    if (debouncedQuery) {
-      searchAPI(debouncedQuery);
-    }
-  }, [debouncedQuery]);
+  const debouncedSearch = useDebounce((value: string) => {
+    // Actual API call
+    searchAPI(value);
+  }, 300);
 
-  return <input value={query} onChange={e => setQuery(e.target.value)} />;
+  return (
+    <input
+      value={query}
+      onChange={e => {
+        setQuery(e.target.value);
+        debouncedSearch(e.target.value);
+      }}
+      placeholder="Enter search term"
+    />
+  );
 }
 ```
+
+The debounced function exposes `.cancel()`, and pending calls are cancelled automatically when the component unmounts.
 
 ## What's Included
 
 ### Hooks
 
-| Hook                      | Description                                         |
-| ------------------------- | --------------------------------------------------- |
-| `useBooleanState`         | Manage boolean state with handlers                  |
-| `useDebounce`             | Debounce a value                                    |
-| `useDebouncedCallback`    | Debounce a callback function                        |
-| `useInterval`             | Set up intervals declaratively                      |
-| `useIntersectionObserver` | Observe element visibility                          |
-| `usePreservedCallback`    | Stable callback reference                           |
-| `usePreservedReference`   | Stable object reference                             |
-| ...                       | [See all hooks](https://react-simplikit.slash.page) |
+| Hook                      | Description                                           |
+| ------------------------- | ----------------------------------------------------- |
+| `useBooleanState`         | Manage boolean state with handlers                    |
+| `useDebounce`             | Debounce a callback function                          |
+| `useDebouncedCallback`    | Debounce an `onChange` callback via an options object |
+| `useInterval`             | Set up intervals declaratively                        |
+| `useIntersectionObserver` | Observe element visibility                            |
+| `usePreservedCallback`    | Stable callback reference                             |
+| `usePreservedReference`   | Stable object reference                               |
+| ...                       | [See all hooks](https://react-simplikit.slash.page)   |
 
 ### Components
 


### PR DESCRIPTION
# Overview

Closes #413

All four READMEs' Quick Start called `useDebounce(query, 300)` to debounce a value; the hook debounces a **callback** (`useDebounce.ts:50`), so the first code a visitor copies was a type error.

## Changes

### Quick Start — replaced with the canonical callback example (all four READMEs)

```diff
-  const debouncedQuery = useDebounce(query, 300);
-
-  useEffect(() => {
-    if (debouncedQuery) {
-      searchAPI(debouncedQuery);
-    }
-  }, [debouncedQuery]);
-
-  return <input value={query} onChange={e => setQuery(e.target.value)} />;
+  const debouncedSearch = useDebounce((value: string) => {
+    // Actual API call
+    searchAPI(value);
+  }, 300);
+
+  return (
+    <input
+      value={query}
+      onChange={e => {
+        setQuery(e.target.value);
+        debouncedSearch(e.target.value);
+      }}
+      placeholder="Enter search term"
+    />
+  );
```

The replacement is the hook's own JSDoc `@example` (`useDebounce.ts:29-48`), also the docs-site example — README and docs now show the identical component. Korean READMEs mirror the Korean docs example (`// 실제 API 호출`, `"검색어를 입력하세요"`). One line of prose added under the snippet: the debounced function exposes `.cancel()` and pending calls are cancelled on unmount (both from the implementation).

### Hooks table — `useDebounce` row corrected, `useDebouncedCallback` row differentiated

```diff
-| `useDebounce`          | Debounce a value             |
-| `useDebouncedCallback` | Debounce a callback function |
+| `useDebounce`          | Debounce a callback function                          |
+| `useDebouncedCallback` | Debounce an `onChange` callback via an options object |
```

## Verification

- Type proof: the old snippet fails `yarn workspace react-simplikit typecheck` with `TS2345`; the new one passes with zero errors.
- Runtime proof: rendered under fake timers — three rapid keystrokes update the controlled input immediately, and `searchAPI` fires exactly once with the final value after 300ms.
- EN README block diffs clean against `useDebounce.md`'s example; KO against `ko/useDebounce.md` (only the added imports differ).
- `yarn fix` is clean.

## Notes

- No changeset, matching #399 / #409 — README-only.
- The peer-suggested handler polish (extract `e.target.value` once) was deliberately not taken, to keep the README byte-aligned with the JSDoc/docs example; if wanted it should land in the JSDoc first and flow out through `docs:gen`.

## Checklist

- [ ] Did you write the test code? — N/A, documentation only (scratch proofs were run, then removed)
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line? — N/A, no source changes
- [ ] Did you write the JSDoc? — N/A, no source changes
