### PR TITLE
docs(core): sync the why-page example with the actual Separated and useLoading APIs

### DIFF
--- a/docs/core/why-react-simplikit-matters.md
+++ b/docs/core/why-react-simplikit-matters.md
@@ -125,12 +125,14 @@ function AutoCompleteInput() {
       return;
     }
 
-    const response = await fetch(`/api/search?q=${searchQuery}`)
-      .then(res => res.json())
-      .catch(error => {
-        console.error('Failed to fetch results:', error);
-        return [];
-      });
+    const response = await startLoading(
+      fetch(`/api/search?q=${searchQuery}`)
+        .then(res => res.json())
+        .catch(error => {
+          console.error('Failed to fetch results:', error);
+          return [];
+        })
+    );
 
     setResults(response);
   }, 300);
@@ -146,7 +148,7 @@ function AutoCompleteInput() {
         onChange={e => {
           setQuery(e.target.value);
           openSearchBox();
-          startLoading(searchResults(e.target.value));
+          searchResults(e.target.value);
         }}
         onFocus={openSearchBox}
         placeholder="Enter search term"
@@ -157,7 +159,7 @@ function AutoCompleteInput() {
           LOADING: () => <div>Searching...</div>,
           EMPTY: () => <div>No results found.</div>,
           RESULT_EXISTS: () => (
-            <Separated with={<Divider />}>
+            <Separated by={<Divider />}>
               {results.map(result => (
                 <Fragment key={result.id}>
                   <div

--- a/docs/ko/core/why-react-simplikit-matters.md
+++ b/docs/ko/core/why-react-simplikit-matters.md
@@ -125,12 +125,14 @@ function AutoCompleteInput() {
       return;
     }
 
-    const response = await fetch(`/api/search?q=${searchQuery}`)
-      .then(res => res.json())
-      .catch(error => {
-        console.error('Failed to fetch results:', error);
-        return [];
-      });
+    const response = await startLoading(
+      fetch(`/api/search?q=${searchQuery}`)
+        .then(res => res.json())
+        .catch(error => {
+          console.error('Failed to fetch results:', error);
+          return [];
+        })
+    );
 
     setResults(response);
   }, 300);
@@ -146,7 +148,7 @@ function AutoCompleteInput() {
         onChange={e => {
           setQuery(e.target.value);
           openSearchBox();
-          startLoading(searchResults(e.target.value));
+          searchResults(e.target.value);
         }}
         onFocus={openSearchBox}
         placeholder="검색어를 입력하세요"
@@ -157,7 +159,7 @@ function AutoCompleteInput() {
           LOADING: () => <div>검색 중...</div>,
           EMPTY: () => <div>검색 결과가 없습니다.</div>,
           RESULT_EXISTS: () => (
-            <Separated with={<Divider />}>
+            <Separated by={<Divider />}>
               {results.map(result => (
                 <Fragment key={result.id}>
                   <div


### PR DESCRIPTION
# Overview

Closes #415

The why-page's flagship `AutoCompleteInput` example did not compile: `Separated` was passed a nonexistent `with` prop, and the `void` result of a debounced call was piped into `startLoading`. Both fixed so the example type-checks and behaves as the page promises (EN + KO).

## Changes

### `<Separated with={...}>` → `<Separated by={...}>`

```diff
-            <Separated with={<Divider />}>
+            <Separated by={<Divider />}>
```

`with=` was a `TS2322` and failed silently at runtime — the destructured separator stays `undefined`, so the list rendered with zero dividers.

### `startLoading` moved inside the debounced callback

```diff
-    const response = await fetch(`/api/search?q=${searchQuery}`)
-      .then(res => res.json())
-      .catch(error => {
-        console.error('Failed to fetch results:', error);
-        return [];
-      });
+    const response = await startLoading(
+      fetch(`/api/search?q=${searchQuery}`)
+        .then(res => res.json())
+        .catch(error => {
+          console.error('Failed to fetch results:', error);
+          return [];
+        })
+    );
```

```diff
           setQuery(e.target.value);
           openSearchBox();
-          startLoading(searchResults(e.target.value));
+          searchResults(e.target.value);
```

The debounced function returns `void`, so the old shape was a `TS2345` and could never show the `LOADING` branch (`await undefined` settles in one microtask). `startLoading` now wraps the promise it is designed to track — its own documented usage — so `isLoading` is `true` exactly while the fetch is in flight.

## Verification

- Before: materializing the whole block yields exactly the two errors; with only the `by=` fix, `TS2345` remains. After: `typecheck` passes with zero errors.
- Runtime (Separated): `by=` renders 2 separators for 3 children, none trailing; `with=` renders 0, silently.
- Runtime (end to end): stubbed `fetch` + fake timers — no fetch during the 300ms debounce window; then fetch fires once with `Searching...` visible while pending; on resolve, both results render with one divider between them. Passed first run, example code unmodified.
- EN/KO blocks remain identical modulo display strings; `yarn fix` clean.

## Notes

- No changeset — docs-site content only.
- Out of scope (tracked in #415): `useOutsideClickEffect` ref misuse + deprecated-hook showcase; `useDebounce` JSDoc `@returns` overstatement.

## Checklist

- [ ] Did you write the test code? — N/A, documentation only (scratch proofs were run, then removed)
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line? — N/A, no source changes
- [ ] Did you write the JSDoc? — N/A, no source changes
