### PR TITLE
fix(useInputState): widen the onChange handler type to accept textarea tag

### DIFF
--- a/.changeset/tasty-ducks-sit.md
+++ b/.changeset/tasty-ducks-sit.md
@@ -1,0 +1,5 @@
+---
+'react-simplikit': patch
+---
+
+The returned handler was typed as `ChangeEventHandler<HTMLInputElement>`, so passing it to a `<textarea>` raised a type error even though the runtime behavior was identical. The handler is now typed as `ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>`, so it can be attached to both `<input>` and `<textarea>` elements.

--- a/packages/core/src/hooks/useInputState/ko/useInputState.md
+++ b/packages/core/src/hooks/useInputState/ko/useInputState.md
@@ -1,6 +1,6 @@
 # useInputState
 
-`useInputState`는 입력 상태를 관리하는 리액트 훅이에요. 선택적으로 값 변환 함수를 지정할 수도 있어요.
+`useInputState`는 입력 상태를 관리하는 리액트 훅이에요. 선택적으로 값 변환 함수를 지정할 수도 있어요. 반환되는 `onChange` 핸들러는 `<input>`과 `<textarea>` 두 요소 모두에서 사용할 수 있어요.
 
 ## 인터페이스
 
@@ -8,7 +8,10 @@
 function useInputState(
   initialValue: string = '',
   transformValue: (value: string) => string = (v: string) => v
-): [value: string, onChange: ChangeEventHandler<HTMLInputElement>];
+): [
+  value: string,
+  onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>,
+];
 ```
 
 ### 파라미터
@@ -29,17 +32,19 @@ function useInputState(
 
 <Interface
   name=""
-  type="[value: string, onChange: ChangeEventHandler<HTMLInputElement>]"
+  type="[value: string, onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>]"
   description="튜플을 포함해요:"
   :nested="[
     {
       name: 'value',
       type: 'string',
+      required: false,
       description: '현재 상태 값이에요.',
     },
     {
       name: 'onChange',
-      type: 'ChangeEventHandler<HTMLInputElement>',
+      type: 'ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>',
+      required: false,
       description: '상태를 업데이트하는 함수예요.',
     },
   ]"
@@ -50,6 +55,11 @@ function useInputState(
 ```tsx
 function Example() {
   const [value, onChange] = useInputState('');
-  return <input type="text" value={value} onChange={onChange} />;
+  return (
+    <>
+      <input type="text" value={value} onChange={onChange} />
+      <textarea value={value} onChange={onChange} />
+    </>
+  );
 }
 ```

--- a/packages/core/src/hooks/useInputState/useInputState.md
+++ b/packages/core/src/hooks/useInputState/useInputState.md
@@ -1,6 +1,6 @@
 # useInputState
 
-`useInputState` is a React hook that manages an input state with optional value transformation.
+`useInputState` is a React hook that manages an input state with optional value transformation. The returned `onChange` handler works with both `<input>` and `<textarea>` elements.
 
 ## Interface
 
@@ -8,7 +8,10 @@
 function useInputState(
   initialValue: string = '',
   transformValue: (value: string) => string = (v: string) => v
-): [value: string, onChange: ChangeEventHandler<HTMLInputElement>];
+): [
+  value: string,
+  onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>,
+];
 ```
 
 ### Parameters
@@ -29,17 +32,19 @@ function useInputState(
 
 <Interface
   name=""
-  type="[value: string, onChange: ChangeEventHandler<HTMLInputElement>]"
+  type="[value: string, onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>]"
   description="tuple containing:"
   :nested="[
     {
       name: 'value',
       type: 'string',
+      required: false,
       description: 'The current state value.',
     },
     {
       name: 'onChange',
-      type: 'ChangeEventHandler<HTMLInputElement>',
+      type: 'ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>',
+      required: false,
       description: 'A function to update the state.',
     },
   ]"
@@ -50,6 +55,11 @@ function useInputState(
 ```tsx
 function Example() {
   const [value, onChange] = useInputState('');
-  return <input type="text" value={value} onChange={onChange} />;
+  return (
+    <>
+      <input type="text" value={value} onChange={onChange} />
+      <textarea value={value} onChange={onChange} />
+    </>
+  );
 }
 ```

--- a/packages/core/src/hooks/useInputState/useInputState.spec.ts
+++ b/packages/core/src/hooks/useInputState/useInputState.spec.ts
@@ -19,6 +19,18 @@ function createTestInput(...params: Parameters<typeof useInputState>) {
   };
 }
 
+function createTestTextarea(...params: Parameters<typeof useInputState>) {
+  return function Textarea() {
+    const [value, onChange] = useInputState(...params);
+
+    return createElement('textarea', {
+      'data-testid': 'textarea',
+      value,
+      onChange,
+    });
+  };
+}
+
 describe('useInputState', () => {
   it('should return empty string for initial value when no argument is provided', async () => {
     const { result } = await renderHookSSR(() => useInputState());
@@ -56,4 +68,14 @@ it('should transform value according to the provided function', async () => {
   fireEvent.change(input, { target: { value: 'must be uppercase' } });
 
   expect(input.value).toBe('MUST BE UPPERCASE');
+});
+
+it('should update value when change event occurs on a textarea', async () => {
+  const { getByTestId } = render(createElement(createTestTextarea()));
+  const textarea = getByTestId('textarea') as HTMLTextAreaElement;
+
+  expect(textarea.value).toBe('');
+
+  fireEvent.change(textarea, { target: { value: 'changed' } });
+  expect(textarea.value).toBe('changed');
 });

--- a/packages/core/src/hooks/useInputState/useInputState.spec.ts
+++ b/packages/core/src/hooks/useInputState/useInputState.spec.ts
@@ -11,7 +11,6 @@ function createTestInput(...params: Parameters<typeof useInputState>) {
     const [value, onChange] = useInputState(...params);
 
     return createElement('input', {
-      'data-testid': 'input',
       type: 'text',
       value,
       onChange,
@@ -24,7 +23,6 @@ function createTestTextarea(...params: Parameters<typeof useInputState>) {
     const [value, onChange] = useInputState(...params);
 
     return createElement('textarea', {
-      'data-testid': 'textarea',
       value,
       onChange,
     });
@@ -49,33 +47,33 @@ describe('useInputState', () => {
 });
 
 it('should update value when change event occurs', async () => {
-  const { getByTestId } = render(createElement(createTestInput()));
-  const input = getByTestId('input') as HTMLInputElement;
+  const { getByRole } = render(createElement(createTestInput()));
+  const input = getByRole('textbox');
 
-  expect(input.value).toBe('');
+  expect(input).toHaveValue('');
 
   fireEvent.change(input, { target: { value: 'changed' } });
-  expect(input.value).toBe('changed');
+  expect(input).toHaveValue('changed');
 
   fireEvent.change(input, { target: { value: 'one more changed' } });
-  expect(input.value).toBe('one more changed');
+  expect(input).toHaveValue('one more changed');
 });
 
 it('should transform value according to the provided function', async () => {
-  const { getByTestId } = render(createElement(createTestInput('', v => v.toUpperCase())));
+  const { getByRole } = render(createElement(createTestInput('', v => v.toUpperCase())));
 
-  const input = getByTestId('input') as HTMLInputElement;
+  const input = getByRole('textbox');
   fireEvent.change(input, { target: { value: 'must be uppercase' } });
 
-  expect(input.value).toBe('MUST BE UPPERCASE');
+  expect(input).toHaveValue('MUST BE UPPERCASE');
 });
 
 it('should update value when change event occurs on a textarea', async () => {
-  const { getByTestId } = render(createElement(createTestTextarea()));
-  const textarea = getByTestId('textarea') as HTMLTextAreaElement;
+  const { getByRole } = render(createElement(createTestTextarea()));
+  const textarea = getByRole('textbox');
 
-  expect(textarea.value).toBe('');
+  expect(textarea).toHaveValue('');
 
   fireEvent.change(textarea, { target: { value: 'changed' } });
-  expect(textarea.value).toBe('changed');
+  expect(textarea).toHaveValue('changed');
 });

--- a/packages/core/src/hooks/useInputState/useInputState.ts
+++ b/packages/core/src/hooks/useInputState/useInputState.ts
@@ -1,28 +1,36 @@
 import { ChangeEvent, ChangeEventHandler, useCallback, useState } from 'react';
 
+type InputLikeElement = HTMLInputElement | HTMLTextAreaElement;
+
 /**
  * @description
  * `useInputState` is a React hook that manages an input state with optional value transformation.
+ * The returned `onChange` handler works with both `<input>` and `<textarea>` elements.
  *
  * @param {string} [initialValue=""] - The initial value of the input. Defaults to an empty string (`""`).
  * @param {(value: string) => string} [transformValue=(v: string) => v] - A function to transform the input value.
  *   Defaults to an identity function that returns the input unchanged.
  *
- * @returns {[value: string, onChange: ChangeEventHandler<HTMLInputElement>]} A tuple containing:
+ * @returns {[value: string, onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>]} A tuple containing:
  * - value `string` - The current state value;
- * - onChange `ChangeEventHandler<HTMLInputElement>` - A function to update the state;
+ * - onChange `ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>` - A function to update the state;
  *
  * @example
  * function Example() {
  *   const [value, onChange] = useInputState('');
- *   return <input type="text" value={value} onChange={onChange} />;
+ *   return (
+ *     <>
+ *       <input type="text" value={value} onChange={onChange} />
+ *       <textarea value={value} onChange={onChange} />
+ *     </>
+ *   );
  * }
  */
 export function useInputState(initialValue = '', transformValue: (value: string) => string = echo) {
   const [value, setValue] = useState(initialValue);
 
-  const handleValueChange: ChangeEventHandler<HTMLInputElement> = useCallback(
-    ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
+  const handleValueChange: ChangeEventHandler<InputLikeElement> = useCallback(
+    ({ target: { value } }: ChangeEvent<InputLikeElement>) => {
       setValue(transformValue(value));
     },
     [transformValue]


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->
I ran into a type error when trying to use `useInputState` with a `<textarea>`. I think this is because the `onChange` generic currently only accepts `input` elements.

Since `<textarea>` serves essentially the same role as an input from the perspective of handling user input, I think it would make sense for `useInputState` to support it as well.

Would it be possible to allow `useInputState` to accept InputLike elements, including `<textarea>`?


## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
