### PR TITLE
docs(agents): add Simplified Chinese and Spanish review criteria

### DIFF
--- a/.claude/agents/agent-translation-reviewer.md
+++ b/.claude/agents/agent-translation-reviewer.md
@@ -120,39 +120,40 @@ return-value descriptions, and table cells.
 
 **Register:** 书面语 — written technical prose, not conversational. Second person is 你, never
 您: the English source addresses the reader informally, and 您 reads as marketing copy in
-developer documentation. Chinese prose takes full-width punctuation — `，。：；、（）` — with
-`“”` as the quotation marks and `「」` reserved for a quote nested inside another quote.
-Half-width punctuation stays inside code blocks, identifiers, and inline code spans. Do not
-insert a typographic space between a Chinese character and an inline code span or a Latin
-identifier; the source Markdown does not carry one and Prettier will not preserve one. Use
-库 for "library", not 类库.
+developer documentation. Chinese prose takes full-width punctuation — `，。：；、（）？！——……《》`
+— with `“”` as the quotation marks and `‘’` reserved for a quote nested inside another quote.
+Half-width punctuation stays inside code blocks, identifiers, and inline code spans. Insert a
+half-width space between a Chinese character and an adjacent Latin word, digit, or inline code
+span (使用 `useDebounce` 这个 Hook 来处理 React 中的输入；14 个依赖), but never between a Chinese
+character and full-width punctuation, which already carries its own spacing. Use 库 for
+"library", not 类库.
 
-| English               | 简体中文             |
-| --------------------- | -------------------- |
-| Hook                  | Hook（不译作“钩子”） |
-| Component             | 组件                 |
-| Utility               | 工具函数             |
-| Guide                 | 指南                 |
-| Reference             | 参考                 |
-| Introduction          | 简介                 |
-| Installation          | 安装                 |
-| Design Principles     | 设计原则             |
-| Contributing          | 贡献指南             |
-| Roadmap               | 路线图               |
-| Parameters            | 参数                 |
-| Return Value          | 返回值               |
-| Example               | 示例                 |
-| Bundle size           | 包体积               |
-| Dependency            | 依赖                 |
-| Zero dependencies     | 零依赖               |
-| Server-side rendering | 服务端渲染           |
-| Callback              | 回调                 |
-| State                 | 状态                 |
-| Rendering             | 渲染                 |
-| Cleanup               | 清理                 |
-| Deprecated            | 已弃用               |
-| Test coverage         | 测试覆盖率           |
-| Type-safe             | 类型安全             |
+| English               | 简体中文   |
+| --------------------- | ---------- |
+| Hook                  | Hook       |
+| Component             | 组件       |
+| Utility               | 工具函数   |
+| Guide                 | 指南       |
+| Reference             | 参考       |
+| Introduction          | 简介       |
+| Installation          | 安装       |
+| Design Principles     | 设计原则   |
+| Contributing          | 贡献指南   |
+| Roadmap               | 路线图     |
+| Parameters            | 参数       |
+| Return Value          | 返回值     |
+| Example               | 示例       |
+| Bundle size           | 包体积     |
+| Dependency            | 依赖       |
+| Zero dependencies     | 零依赖     |
+| Server-side rendering | 服务端渲染 |
+| Callback              | 回调       |
+| State                 | 状态       |
+| Rendering             | 渲染       |
+| Cleanup               | 清理       |
+| Deprecated            | 已弃用     |
+| Test coverage         | 测试覆盖率 |
+| Type-safe             | 类型安全   |
 
 **Keep in the original script:** `react-simplikit`, `React`, `TypeScript`, `npm`, `yarn`,
 `pnpm`, `ref`, `props`, `JSDoc`, `SSR`, `MIT`, and every hook/component/util name. `Hook`
@@ -167,12 +168,17 @@ is kept in English as well, matching React 官方中文文档 — never 钩子.
 - English word order preserved through a relative clause that Chinese would front or split
   ("a hook that returns a value which changes on resize" must not become one 定语 stack)
 - Stacked 的 chains (“React 的 Hook 的测试的覆盖率”) where one 的 or a rewrite suffices
-- Half-width punctuation in Chinese prose (`,` `.` `:` `(` `)`), or full-width punctuation
-  inside a code block, an identifier, or an inline code span
-- Over-long sentences that Chinese would split at a 逗号 boundary — one English sentence
-  carrying three clauses becomes two or three 短句, not a single 长句
-- Translating a UI label or a proper noun the source deliberately left in English (button
-  text, `Deprecated` badges, package names, heading anchors)
+- Half-width punctuation in Chinese prose (`,` `.` `:` `?` `!` `(` `)`), or full-width
+  punctuation inside a code block, an identifier, or an inline code span
+- Missing half-width space between a Chinese character and an adjacent Latin word, digit, or
+  inline code span — 使用`useDebounce`处理 should read 使用 `useDebounce` 处理
+- Over-long sentences carried straight over from English — split at a 逗号 or 分号 boundary
+  when the result is hard to parse in one pass. Judge by readability, not by clause count; a
+  multi-clause sentence can be perfectly natural in Chinese
+- Translating a proper noun or identifier the source deliberately left in English: package
+  names (`@react-simplikit/mobile`), prop and option names, npm script names. The converse
+  also fails review — `deprecated` used as an ordinary adjective in prose is translated
+  (已弃用); only the identifier beside it stays in English
 
 ## Spanish (`es`)
 
@@ -181,53 +187,62 @@ exist, use the term understood everywhere: `computadora` (not `ordenador`), `arc
 `fichero`), `video` (not `vídeo`), `hacer clic` (not `pinchar` or `cliquear`), `ejecutar`
 (not `correr`), `biblioteca` (not `librería`), and `ustedes` — never the Spain-only
 `vosotros`. Address the reader as `tú`, never `usted`; this matches the English source's
-register, the same way the Japanese section chooses です・ます over 敬語. Headings name the
-action with a noun or an infinitive, never a conjugated imperative (`Instalación`,
-`Contribuir`, `Empezar`), while instructions in body text take the `tú` imperative
-(`instala` — not `instale`, and not `instalar`). Opening `¿` and `¡` are required on every
-question and exclamation. Glossary cells below are lowercase; capitalization follows from the
-position a term lands in.
+register, the same way the Japanese section chooses です・ます over 敬語. Explanatory prose
+stays in second-person `tú` throughout (`cuando llamas a useState`); the impersonal `se`
+(`cuando se llama a useState`) is allowed only where the actor is genuinely React rather than
+the reader. Headings name the action with a noun or an infinitive, never a conjugated
+imperative (`Instalación`, `Contribuir`, `Empezar`), while instructions in body text take the
+`tú` imperative (`instala` — not `instale`, and not `instalar`). Headings and titles take
+sentence case (`Principios de diseño`) regardless of the English source's Title Case; only
+proper nouns and terms from the do-not-translate list keep their capitals. Opening `¿` and `¡`
+are required on every question and exclamation, and quotations take `“ ”` (with `‘ ’` nested)
+— never the straight `" "` carried over from the source. Adjectival glossary entries are cited
+in masculine singular and must agree with the noun they modify (`obsoleto` → `una API
+obsoleta`).
 
-| English               | Español                                   |
-| --------------------- | ----------------------------------------- |
-| Hook                  | Hook (m.: el Hook, los Hooks)             |
-| Component             | componente                                |
-| Utility               | utilidad                                  |
-| Guide                 | guía                                      |
-| Reference             | referencia                                |
-| Introduction          | introducción                              |
-| Installation          | instalación                               |
-| Design Principles     | principios de diseño                      |
-| Contributing          | contribuir                                |
-| Roadmap               | hoja de ruta                              |
-| Parameters            | parámetros                                |
-| Return Value          | valor de retorno                          |
-| Example               | ejemplo                                   |
-| Bundle size           | tamaño del bundle                         |
-| Dependency            | dependencia                               |
-| Zero dependencies     | cero dependencias                         |
-| Server-side rendering | renderizado en el servidor                |
-| Callback              | callback (m.: el callback, los callbacks) |
-| State                 | estado                                    |
-| Rendering             | renderizado                               |
-| Cleanup               | limpieza                                  |
-| Deprecated            | obsoleto                                  |
-| Test coverage         | cobertura de pruebas                      |
-| Type-safe             | con seguridad de tipos                    |
+| English               | Español                    |
+| --------------------- | -------------------------- |
+| Hook                  | Hook                       |
+| Component             | componente                 |
+| Utility               | utilidad                   |
+| Guide                 | guía                       |
+| Reference             | referencia                 |
+| Introduction          | introducción               |
+| Installation          | instalación                |
+| Design Principles     | principios de diseño       |
+| Contributing          | contribuir                 |
+| Roadmap               | hoja de ruta               |
+| Parameters            | parámetros                 |
+| Return Value          | valor de retorno           |
+| Example               | ejemplo                    |
+| Bundle size           | tamaño del bundle          |
+| Dependency            | dependencia                |
+| Zero dependencies     | cero dependencias          |
+| Server-side rendering | renderizado en el servidor |
+| Callback              | callback                   |
+| State                 | estado                     |
+| Rendering             | renderizado                |
+| Cleanup               | limpieza                   |
+| Deprecated            | obsoleto                   |
+| Test coverage         | cobertura de pruebas       |
+| Type-safe             | con seguridad de tipos     |
 
 **Keep in the original script:** `react-simplikit`, `React`, `TypeScript`, `npm`, `yarn`,
 `pnpm`, `ref`, `props`, `JSDoc`, `SSR`, `MIT`, and every hook/component/util name. `Hook`,
 `callback`, and `bundle` are kept as loanwords rather than calqued. Their gender in Spanish
-prose is fixed: `el Hook` / `los Hooks`, `el callback`, `el bundle`, `los props` (never
-`las props`), and `la ref` (feminine, by analogy with `referencia`).
+prose is fixed: `el Hook` / `los Hooks`, `el callback`, `el bundle`, `las props` (feminine, by
+analogy with `propiedades` — this is what `es.react.dev` writes), and `la ref` (feminine, by
+analogy with `referencia`). Nothing in this list counts as an anglicismo for the purpose of
+the first failure mode below.
 
 **Recurring failure modes in ES technical translation — check these explicitly:**
 
 - Unnecessary anglicismos where a standard Spanish term exists: `rendimiento` not
   `performance`, `es compatible con` not `soporta`, `predeterminado` not `default`,
-  `enlace` not `link`, `almacenar en caché` not `cachear`
+  `enlace` not `link`, `almacenar en caché` not `cachear`. Terms in the do-not-translate
+  list above are never anglicismos for this purpose — do not flag `bundle` or `callback`
 - Gender and number agreement, especially with loanwords of unclear gender (`el Hook`,
-  `los props`, `el callback`, `la ref`) and across long noun phrases — `registradas`, not
+  `las props`, `el callback`, `la ref`) and across long noun phrases — `registradas`, not
   `registrados`, in `las funciones de limpieza registradas`
 - Gerundio used where Spanish needs an infinitive or a relative clause: `que usa el estado`,
   not `usando el estado`; `para instalar`, not `instalando`. A gerundio must not describe an
@@ -236,8 +251,10 @@ prose is fixed: `el Hook` / `los Hooks`, `el callback`, `el bundle`, `los props`
   `cobertura de las pruebas de los Hooks de React`, unwound right to left with `de`
 - Missing `¿` / `¡` opening marks, and missing accents where the accent carries meaning
   (`más`/`mas`, `sí`/`si`, `qué`/`que`, `tú`/`tu`, `él`/`el`, `está`/`esta`, `aún`/`aun`)
-- Translating a UI label or a proper noun the source deliberately left in English (button
-  text, `Deprecated` badges, package names, heading anchors)
+- Translating a proper noun or identifier the source deliberately left in English: package
+  names (`@react-simplikit/mobile`), prop and option names, npm script names. The converse
+  also fails review — `deprecated` used as an ordinary adjective in prose is translated
+  (`obsoleto`, agreeing with its noun); only the identifier beside it stays in English
 
 ## Adding a language
 

--- a/.claude/agents/agent-translation-reviewer.md
+++ b/.claude/agents/agent-translation-reviewer.md
@@ -116,6 +116,129 @@ return-value descriptions, and table cells.
 - 半角/全角 inconsistency around parentheses and colons
 - Translating a UI label that the source deliberately left in English
 
+## Simplified Chinese (`zh-Hans`)
+
+**Register:** 书面语 — written technical prose, not conversational. Second person is 你, never
+您: the English source addresses the reader informally, and 您 reads as marketing copy in
+developer documentation. Chinese prose takes full-width punctuation — `，。：；、（）` — with
+`“”` as the quotation marks and `「」` reserved for a quote nested inside another quote.
+Half-width punctuation stays inside code blocks, identifiers, and inline code spans. Do not
+insert a typographic space between a Chinese character and an inline code span or a Latin
+identifier; the source Markdown does not carry one and Prettier will not preserve one. Use
+库 for "library", not 类库.
+
+| English               | 简体中文             |
+| --------------------- | -------------------- |
+| Hook                  | Hook（不译作“钩子”） |
+| Component             | 组件                 |
+| Utility               | 工具函数             |
+| Guide                 | 指南                 |
+| Reference             | 参考                 |
+| Introduction          | 简介                 |
+| Installation          | 安装                 |
+| Design Principles     | 设计原则             |
+| Contributing          | 贡献指南             |
+| Roadmap               | 路线图               |
+| Parameters            | 参数                 |
+| Return Value          | 返回值               |
+| Example               | 示例                 |
+| Bundle size           | 包体积               |
+| Dependency            | 依赖                 |
+| Zero dependencies     | 零依赖               |
+| Server-side rendering | 服务端渲染           |
+| Callback              | 回调                 |
+| State                 | 状态                 |
+| Rendering             | 渲染                 |
+| Cleanup               | 清理                 |
+| Deprecated            | 已弃用               |
+| Test coverage         | 测试覆盖率           |
+| Type-safe             | 类型安全             |
+
+**Keep in the original script:** `react-simplikit`, `React`, `TypeScript`, `npm`, `yarn`,
+`pnpm`, `ref`, `props`, `JSDoc`, `SSR`, `MIT`, and every hook/component/util name. `Hook`
+is kept in English as well, matching React 官方中文文档 — never 钩子.
+
+**Recurring failure modes in ZH-Hans technical translation — check these explicitly:**
+
+- Traditional-character glyphs leaking into Simplified text (為/为, 對/对, 傳/传, 開/开,
+  說/说), including inside code comments, image alt text, and frontmatter values
+- Taiwan/Hong Kong vocabulary in a Simplified document: 软件 not 軟體, 默认 not 預設,
+  网络 not 網路, 用户 not 使用者, 组件 not 元件, 内存 not 記憶體
+- English word order preserved through a relative clause that Chinese would front or split
+  ("a hook that returns a value which changes on resize" must not become one 定语 stack)
+- Stacked 的 chains (“React 的 Hook 的测试的覆盖率”) where one 的 or a rewrite suffices
+- Half-width punctuation in Chinese prose (`,` `.` `:` `(` `)`), or full-width punctuation
+  inside a code block, an identifier, or an inline code span
+- Over-long sentences that Chinese would split at a 逗号 boundary — one English sentence
+  carrying three clauses becomes two or three 短句, not a single 长句
+- Translating a UI label or a proper noun the source deliberately left in English (button
+  text, `Deprecated` badges, package names, heading anchors)
+
+## Spanish (`es`)
+
+**Register:** Neutral, international Spanish — no region-locked vocabulary. Where variants
+exist, use the term understood everywhere: `computadora` (not `ordenador`), `archivo` (not
+`fichero`), `video` (not `vídeo`), `hacer clic` (not `pinchar` or `cliquear`), `ejecutar`
+(not `correr`), `biblioteca` (not `librería`), and `ustedes` — never the Spain-only
+`vosotros`. Address the reader as `tú`, never `usted`; this matches the English source's
+register, the same way the Japanese section chooses です・ます over 敬語. Headings name the
+action with a noun or an infinitive, never a conjugated imperative (`Instalación`,
+`Contribuir`, `Empezar`), while instructions in body text take the `tú` imperative
+(`instala` — not `instale`, and not `instalar`). Opening `¿` and `¡` are required on every
+question and exclamation. Glossary cells below are lowercase; capitalization follows from the
+position a term lands in.
+
+| English               | Español                                   |
+| --------------------- | ----------------------------------------- |
+| Hook                  | Hook (m.: el Hook, los Hooks)             |
+| Component             | componente                                |
+| Utility               | utilidad                                  |
+| Guide                 | guía                                      |
+| Reference             | referencia                                |
+| Introduction          | introducción                              |
+| Installation          | instalación                               |
+| Design Principles     | principios de diseño                      |
+| Contributing          | contribuir                                |
+| Roadmap               | hoja de ruta                              |
+| Parameters            | parámetros                                |
+| Return Value          | valor de retorno                          |
+| Example               | ejemplo                                   |
+| Bundle size           | tamaño del bundle                         |
+| Dependency            | dependencia                               |
+| Zero dependencies     | cero dependencias                         |
+| Server-side rendering | renderizado en el servidor                |
+| Callback              | callback (m.: el callback, los callbacks) |
+| State                 | estado                                    |
+| Rendering             | renderizado                               |
+| Cleanup               | limpieza                                  |
+| Deprecated            | obsoleto                                  |
+| Test coverage         | cobertura de pruebas                      |
+| Type-safe             | con seguridad de tipos                    |
+
+**Keep in the original script:** `react-simplikit`, `React`, `TypeScript`, `npm`, `yarn`,
+`pnpm`, `ref`, `props`, `JSDoc`, `SSR`, `MIT`, and every hook/component/util name. `Hook`,
+`callback`, and `bundle` are kept as loanwords rather than calqued. Their gender in Spanish
+prose is fixed: `el Hook` / `los Hooks`, `el callback`, `el bundle`, `los props` (never
+`las props`), and `la ref` (feminine, by analogy with `referencia`).
+
+**Recurring failure modes in ES technical translation — check these explicitly:**
+
+- Unnecessary anglicismos where a standard Spanish term exists: `rendimiento` not
+  `performance`, `es compatible con` not `soporta`, `predeterminado` not `default`,
+  `enlace` not `link`, `almacenar en caché` not `cachear`
+- Gender and number agreement, especially with loanwords of unclear gender (`el Hook`,
+  `los props`, `el callback`, `la ref`) and across long noun phrases — `registradas`, not
+  `registrados`, in `las funciones de limpieza registradas`
+- Gerundio used where Spanish needs an infinitive or a relative clause: `que usa el estado`,
+  not `usando el estado`; `para instalar`, not `instalando`. A gerundio must not describe an
+  action that happens after the main verb
+- English word order preserved in noun stacks: `React hook testing coverage` becomes
+  `cobertura de las pruebas de los Hooks de React`, unwound right to left with `de`
+- Missing `¿` / `¡` opening marks, and missing accents where the accent carries meaning
+  (`más`/`mas`, `sí`/`si`, `qué`/`que`, `tú`/`tu`, `él`/`el`, `está`/`esta`, `aún`/`aun`)
+- Translating a UI label or a proper noun the source deliberately left in English (button
+  text, `Deprecated` badges, package names, heading anchors)
+
 ## Adding a language
 
 Add a section like the Japanese one above: register, glossary table, do-not-translate list,

--- a/.claude/agents/agent-translation-reviewer.md
+++ b/.claude/agents/agent-translation-reviewer.md
@@ -122,7 +122,8 @@ return-value descriptions, and table cells.
 您: the English source addresses the reader informally, and 您 reads as marketing copy in
 developer documentation. Chinese prose takes full-width punctuation — `，。：；、（）？！——……《》`
 — with `“”` as the quotation marks and `‘’` reserved for a quote nested inside another quote.
-Half-width punctuation stays inside code blocks, identifiers, and inline code spans. Insert a
+Half-width punctuation stays inside code blocks, identifiers, inline code spans, and component
+attributes (`<SplitView left-title="...">`, which sit in prose outside any fence). Insert a
 half-width space between a Chinese character and an adjacent Latin word, digit, or inline code
 span (使用 `useDebounce` 这个 Hook 来处理 React 中的输入；14 个依赖), but never between a Chinese
 character and full-width punctuation, which already carries its own spacing. Use 库 for
@@ -175,10 +176,11 @@ is kept in English as well, matching React 官方中文文档 — never 钩子.
 - Over-long sentences carried straight over from English — split at a 逗号 or 分号 boundary
   when the result is hard to parse in one pass. Judge by readability, not by clause count; a
   multi-clause sentence can be perfectly natural in Chinese
-- Translating a proper noun or identifier the source deliberately left in English: package
-  names (`@react-simplikit/mobile`), prop and option names, npm script names. The converse
-  also fails review — `deprecated` used as an ordinary adjective in prose is translated
-  (已弃用); only the identifier beside it stays in English
+- Translating a UI label, proper noun, or identifier the source deliberately left in English:
+  package names (`@react-simplikit/mobile`), prop and option names, npm script names, and UI
+  labels such as badge alt text (`MIT License`, `Discord Badge`). The converse also fails
+  review — `deprecated` used as an ordinary adjective in prose is translated (已弃用); only the
+  identifier beside it stays in English
 
 ## Spanish (`es`)
 
@@ -195,8 +197,10 @@ imperative (`Instalación`, `Contribuir`, `Empezar`), while instructions in body
 `tú` imperative (`instala` — not `instale`, and not `instalar`). Headings and titles take
 sentence case (`Principios de diseño`) regardless of the English source's Title Case; only
 proper nouns and terms from the do-not-translate list keep their capitals. Opening `¿` and `¡`
-are required on every question and exclamation, and quotations take `“ ”` (with `‘ ’` nested)
-— never the straight `" "` carried over from the source. Adjectival glossary entries are cited
+are required on every question and exclamation, and prose quotations take `“ ”` (with `‘ ’`
+nested) — never the straight `" "` carried over from the source. That rule is for prose only:
+straight quotes and half-width punctuation stay byte-identical inside code blocks, identifiers,
+inline code spans, and component attributes (`<SplitView left-title="...">`). Adjectival glossary entries are cited
 in masculine singular and must agree with the noun they modify (`obsoleto` → `una API
 obsoleta`).
 
@@ -251,10 +255,11 @@ the first failure mode below.
   `cobertura de las pruebas de los Hooks de React`, unwound right to left with `de`
 - Missing `¿` / `¡` opening marks, and missing accents where the accent carries meaning
   (`más`/`mas`, `sí`/`si`, `qué`/`que`, `tú`/`tu`, `él`/`el`, `está`/`esta`, `aún`/`aun`)
-- Translating a proper noun or identifier the source deliberately left in English: package
-  names (`@react-simplikit/mobile`), prop and option names, npm script names. The converse
-  also fails review — `deprecated` used as an ordinary adjective in prose is translated
-  (`obsoleto`, agreeing with its noun); only the identifier beside it stays in English
+- Translating a UI label, proper noun, or identifier the source deliberately left in English:
+  package names (`@react-simplikit/mobile`), prop and option names, npm script names, and UI
+  labels such as badge alt text (`MIT License`, `Discord Badge`). The converse also fails
+  review — `deprecated` used as an ordinary adjective in prose is translated (`obsoleto`,
+  agreeing with its noun); only the identifier beside it stays in English
 
 ## Adding a language
 


### PR DESCRIPTION
# Overview

Adds `## Simplified Chinese (zh-Hans)` and `## Spanish (es)` sections to `.claude/agents/agent-translation-reviewer.md` — the criteria the translation reviewer applies when checking a translated doc against its English source. Both follow the Japanese section's structure: register, 24-term glossary, do-not-translate list, recurring failure modes.

No translation ships here. The language-agnostic sections and the Japanese section are byte-identical to `main`.

## Rulings worth knowing

- `Hook` stays English in both languages, matching React's own zh-hans and es docs.
- zh-Hans: half-width space between CJK and Latin/digits/inline code (as `zh-hans.react.dev` and this repo's `ja` locale do); full-width punctuation in prose with `“”`/`‘’` quotes per GB/T 15834 — `「」` is the TW/HK form and is a finding.
- es: neutral/international Spanish (`computadora`, `archivo`, `biblioteca`, `ustedes`); `tú` throughout; sentence-case headings; `callback`/`bundle` kept as loanwords with gender pinned (`el Hook`, `el callback`, `el bundle`, `las props`, `la ref`).

## Stack

Bottom of a 3-PR stack: #442 → #443 (zh-Hans) → #444 (es). Merge from the bottom.

## Checklist

- [x] Did you write the test code? — n/a, agent criteria only
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line? — n/a, package source untouched
- [x] Did you write the JSDoc? — n/a
