### PR TITLE
feat(useDebouncedCallback,useThrottledCallback): accept any value type

### DIFF
--- a/.changeset/generic-callback-value.md
+++ b/.changeset/generic-callback-value.md
@@ -1,0 +1,9 @@
+---
+'react-simplikit': minor
+---
+
+`useDebouncedCallback` and `useThrottledCallback` now accept any value type: `onChange` is typed `(newValue: T) => void` instead of `(newValue: boolean) => void`, so a debounced search query or a throttled scroll position no longer needs a cast. Existing boolean callers are unaffected.
+
+`useDebouncedCallback` no longer drops a first call of `false`. It compared incoming values against a seed of `false`, so the very first `false` looked redundant and was never forwarded; the comparison now starts from a sentinel, as `useThrottledCallback` already did. A `false` that arrives while an initial `true` is still pending now replaces it instead of being ignored.
+
+`useImpressionRef` no longer emits `onImpressionEnd` for an element that was never impressed.

--- a/.scripts/commands/generateSkill/template.md
+++ b/.scripts/commands/generateSkill/template.md
@@ -27,8 +27,8 @@ Backticks in this table mark catalog entries only.
 
 | Need                                                                | Use                                      |
 | ------------------------------------------------------------------- | ---------------------------------------- |
-| Debounce a callback (search input, resize)                          | `useDebounce`                            |
-| Throttle a callback (scroll, pointer move)                          | `useThrottle`                            |
+| Debounce a callback (search input, resize)                          | `useDebounce` / `useDebouncedCallback`   |
+| Throttle a callback (scroll, pointer move)                          | `useThrottle` / `useThrottledCallback`   |
 | Boolean on/off, flip only                                           | `useToggle`                              |
 | Boolean on/off with explicit set-true / set-false                   | `useBooleanState`                        |
 | Numeric state with bounds/step                                      | `useCounter`                             |

--- a/packages/plugin/skills/react-simplikit/SKILL.md
+++ b/packages/plugin/skills/react-simplikit/SKILL.md
@@ -27,8 +27,8 @@ Backticks in this table mark catalog entries only.
 
 | Need                                                                | Use                                      |
 | ------------------------------------------------------------------- | ---------------------------------------- |
-| Debounce a callback (search input, resize)                          | `useDebounce`                            |
-| Throttle a callback (scroll, pointer move)                          | `useThrottle`                            |
+| Debounce a callback (search input, resize)                          | `useDebounce` / `useDebouncedCallback`   |
+| Throttle a callback (scroll, pointer move)                          | `useThrottle` / `useThrottledCallback`   |
 | Boolean on/off, flip only                                           | `useToggle`                              |
 | Boolean on/off with explicit set-true / set-false                   | `useBooleanState`                        |
 | Numeric state with bounds/step                                      | `useCounter`                             |

--- a/packages/plugin/skills/react-simplikit/references/useDebouncedCallback.md
+++ b/packages/plugin/skills/react-simplikit/references/useDebouncedCallback.md
@@ -5,7 +5,7 @@
 ## Interface
 
 ```ts
-function useDebouncedCallback(options: Object): Function;
+function useDebouncedCallback<T>(options: Object): (nextValue: T) => void;
 ```
 
 ### Parameters
@@ -18,9 +18,10 @@ function useDebouncedCallback(options: Object): Function;
   :nested="[
     {
       name: 'options.onChange',
-      type: 'Function',
+      type: '(newValue: T) => void',
       required: true,
-      description: 'The callback function to debounce.',
+      description:
+        'The callback to debounce. A call with the same value as the last forwarded one is skipped.',
     },
     {
       name: 'options.timeThreshold',
@@ -52,21 +53,28 @@ function useDebouncedCallback(options: Object): Function;
 
 <Interface
   name=""
-  type="Function"
-  description="debounced function that delays invoking the callback."
+  type="(nextValue: T) => void"
+  description="debounced function that forwards the value to <code>onChange</code>."
 />
 
 ## Example
 
 ```tsx
+import { useDebouncedCallback } from 'react-simplikit';
+import { useState } from 'react';
+
 function SearchInput() {
   const [query, setQuery] = useState('');
-  const debouncedSetQuery = useDebouncedCallback({
+  const setQueryDebounced = useDebouncedCallback({
     onChange: setQuery,
-    timeThreshold: 100,
+    timeThreshold: 300,
   });
+
   return (
-    <input type="text" onChange={e => debouncedSetQuery(e.target.value)} />
+    <>
+      <input onChange={e => setQueryDebounced(e.target.value)} />
+      <p>Searching for: {query}</p>
+    </>
   );
 }
 ```

--- a/packages/plugin/skills/react-simplikit/references/useThrottledCallback.md
+++ b/packages/plugin/skills/react-simplikit/references/useThrottledCallback.md
@@ -5,7 +5,7 @@
 ## Interface
 
 ```ts
-function useThrottledCallback(options: Object): Function;
+function useThrottledCallback<T>(options: Object): (nextValue: T) => void;
 ```
 
 ### Parameters
@@ -18,9 +18,10 @@ function useThrottledCallback(options: Object): Function;
   :nested="[
     {
       name: 'options.onChange',
-      type: 'Function',
+      type: '(newValue: T) => void',
       required: true,
-      description: 'The callback function to throttle.',
+      description:
+        'The callback to throttle. A call with the same value as the last forwarded one is skipped.',
     },
     {
       name: 'options.timeThreshold',
@@ -43,18 +44,27 @@ function useThrottledCallback(options: Object): Function;
 
 <Interface
   name=""
-  type="Function"
-  description="throttled function that limits invoking the callback."
+  type="(nextValue: T) => void"
+  description="throttled function that forwards the value to <code>onChange</code> at most once per interval."
 />
 
 ## Example
 
 ```tsx
-function ScrollTracker() {
-  const throttledScroll = useThrottledCallback({
-    onChange: (scrollY: number) => console.log(scrollY),
+import { useThrottledCallback } from 'react-simplikit';
+import { useState } from 'react';
+
+function ScrollPosition() {
+  const [scrollTop, setScrollTop] = useState(0);
+  const setScrollTopThrottled = useThrottledCallback({
+    onChange: setScrollTop,
     timeThreshold: 200,
   });
-  return <div onScroll={e => throttledScroll(e.currentTarget.scrollTop)} />;
+
+  return (
+    <div onScroll={e => setScrollTopThrottled(e.currentTarget.scrollTop)}>
+      <p>Scrolled {scrollTop}px</p>
+    </div>
+  );
 }
 ```

--- a/packages/react-simplikit/src/hooks/useDebouncedCallback/ko/useDebouncedCallback.md
+++ b/packages/react-simplikit/src/hooks/useDebouncedCallback/ko/useDebouncedCallback.md
@@ -5,7 +5,7 @@
 ## 인터페이스
 
 ```ts
-function useDebouncedCallback(options: Object): Function;
+function useDebouncedCallback<T>(options: Object): (nextValue: T) => void;
 ```
 
 ### 파라미터
@@ -18,9 +18,10 @@ function useDebouncedCallback(options: Object): Function;
   :nested="[
     {
       name: 'options.onChange',
-      type: 'Function',
+      type: '(newValue: T) => void',
       required: true,
-      description: '디바운스할 콜백 함수예요.',
+      description:
+        '디바운스할 콜백이에요. 마지막으로 전달된 값과 같은 값으로 호출하면 건너뛰어요.',
     },
     {
       name: 'options.timeThreshold',
@@ -52,21 +53,28 @@ function useDebouncedCallback(options: Object): Function;
 
 <Interface
   name=""
-  type="Function"
-  description="콜백 호출을 지연시키는 디바운스된 함수예요."
+  type="(nextValue: T) => void"
+  description="값을 <code>onChange</code>에 전달하는 디바운스된 함수예요."
 />
 
 ## 예시
 
 ```tsx
+import { useDebouncedCallback } from 'react-simplikit';
+import { useState } from 'react';
+
 function SearchInput() {
   const [query, setQuery] = useState('');
-  const debouncedSetQuery = useDebouncedCallback({
+  const setQueryDebounced = useDebouncedCallback({
     onChange: setQuery,
-    timeThreshold: 100,
+    timeThreshold: 300,
   });
+
   return (
-    <input type="text" onChange={e => debouncedSetQuery(e.target.value)} />
+    <>
+      <input onChange={e => setQueryDebounced(e.target.value)} />
+      <p>검색어: {query}</p>
+    </>
   );
 }
 ```

--- a/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.md
+++ b/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.md
@@ -5,7 +5,7 @@
 ## Interface
 
 ```ts
-function useDebouncedCallback(options: Object): Function;
+function useDebouncedCallback<T>(options: Object): (nextValue: T) => void;
 ```
 
 ### Parameters
@@ -18,9 +18,10 @@ function useDebouncedCallback(options: Object): Function;
   :nested="[
     {
       name: 'options.onChange',
-      type: 'Function',
+      type: '(newValue: T) => void',
       required: true,
-      description: 'The callback function to debounce.',
+      description:
+        'The callback to debounce. A call with the same value as the last forwarded one is skipped.',
     },
     {
       name: 'options.timeThreshold',
@@ -52,21 +53,28 @@ function useDebouncedCallback(options: Object): Function;
 
 <Interface
   name=""
-  type="Function"
-  description="debounced function that delays invoking the callback."
+  type="(nextValue: T) => void"
+  description="debounced function that forwards the value to <code>onChange</code>."
 />
 
 ## Example
 
 ```tsx
+import { useDebouncedCallback } from 'react-simplikit';
+import { useState } from 'react';
+
 function SearchInput() {
   const [query, setQuery] = useState('');
-  const debouncedSetQuery = useDebouncedCallback({
+  const setQueryDebounced = useDebouncedCallback({
     onChange: setQuery,
-    timeThreshold: 100,
+    timeThreshold: 300,
   });
+
   return (
-    <input type="text" onChange={e => debouncedSetQuery(e.target.value)} />
+    <>
+      <input onChange={e => setQueryDebounced(e.target.value)} />
+      <p>Searching for: {query}</p>
+    </>
   );
 }
 ```

--- a/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.spec.ts
+++ b/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.spec.ts
@@ -27,19 +27,19 @@ describe('useDebouncedCallback', () => {
     vi.advanceTimersByTime(50);
     expect(onChange).not.toBeCalled();
 
+    // a newer value while the first one is still pending replaces it: only the settled value is forwarded
     result.current(false);
     vi.advanceTimersByTime(50);
-    expect(onChange).toBeCalledTimes(1);
-    expect(onChange).toBeCalledWith(true);
-
-    result.current(false);
-    vi.advanceTimersByTime(50);
-    expect(onChange).toBeCalledTimes(1);
-    expect(onChange).toBeCalledWith(true);
+    expect(onChange).not.toBeCalled();
 
     vi.advanceTimersByTime(50);
-    expect(onChange).toBeCalledTimes(2);
+    expect(onChange).toBeCalledTimes(1);
     expect(onChange).toBeCalledWith(false);
+
+    result.current(true);
+    vi.advanceTimersByTime(100);
+    expect(onChange).toBeCalledTimes(2);
+    expect(onChange).toBeCalledWith(true);
   });
 
   it('should handle leading edge', () => {
@@ -70,6 +70,27 @@ describe('useDebouncedCallback', () => {
     result.current(true);
     vi.advanceTimersByTime(100);
     expect(onChange).toBeCalledTimes(1);
+  });
+
+  it('forwards a string value to onChange', () => {
+    const onChange = vi.fn<(value: string) => void>();
+    const { result } = renderHookSSR(() => useDebouncedCallback({ onChange, timeThreshold: 100 }));
+
+    result.current('react');
+    vi.advanceTimersByTime(100);
+
+    expect(onChange).toBeCalledWith('react');
+  });
+
+  it('invokes the callback when the first value is false', () => {
+    const onChange = vi.fn();
+    const { result } = renderHookSSR(() => useDebouncedCallback({ onChange, timeThreshold: 100 }));
+
+    result.current(false);
+    vi.advanceTimersByTime(100);
+
+    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toBeCalledWith(false);
   });
 
   it('should cleanup on unmount', async () => {

--- a/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.ts
+++ b/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.ts
@@ -9,38 +9,60 @@ type DebounceOptions = {
 };
 
 /**
+ * Marks that no value has been forwarded to `onChange` yet.
+ *
+ * The hook skips redundant invocations by comparing against the last forwarded value, but it
+ * receives no initial value from the caller. Seeding that comparison with a real value would treat
+ * the first call of that value as redundant and swallow it, so an unreachable sentinel is used instead.
+ */
+const NOT_INVOKED = Symbol('NOT_INVOKED');
+
+/**
  * @description
  * `useDebouncedCallback` is a React hook that returns a debounced version of the provided callback function.
  * It helps optimize event handling by delaying function execution and grouping multiple calls into one.
  *
  * Note that if both 'leading' and 'trailing' are set, the function will be called at both the start and end of the delay period. However, it must be called at least twice within debounceMs interval for this to happen, since one debounced function call cannot trigger the function twice.
  *
+ * @template T - The type of the value passed to `onChange`.
  * @param {Object} options - The options object.
- * @param {Function} options.onChange - The callback function to debounce.
+ * @param {(newValue: T) => void} options.onChange - The callback to debounce. A call with the same value as the last forwarded one is skipped.
  * @param {number} options.timeThreshold - The number of milliseconds to delay the function execution.
  * @param {boolean} [options.leading=false] - If `true`, the function is called at the start of the sequence.
  * @param {boolean} [options.trailing=true] - If `true`, the function is called at the end of the sequence.
  *
- * @returns {Function} A debounced function that delays invoking the callback.
+ * @returns {(nextValue: T) => void} A debounced function that forwards the value to `onChange`.
  *
  * @example
+ * import { useDebouncedCallback } from 'react-simplikit';
+ * import { useState } from 'react';
+ *
  * function SearchInput() {
  *   const [query, setQuery] = useState('');
- *   const debouncedSetQuery = useDebouncedCallback({ onChange: setQuery, timeThreshold: 100 });
- *   return <input type="text" onChange={(e) => debouncedSetQuery(e.target.value)} />;
+ *   const setQueryDebounced = useDebouncedCallback({ onChange: setQuery, timeThreshold: 300 });
+ *
+ *   return (
+ *     <>
+ *       <input onChange={e => setQueryDebounced(e.target.value)} />
+ *       <p>Searching for: {query}</p>
+ *     </>
+ *   );
  * }
  */
-export function useDebouncedCallback({
+export function useDebouncedCallback<T>({
   onChange,
   timeThreshold,
   leading = false,
   trailing = true,
 }: DebounceOptions & {
-  onChange: (newValue: boolean) => void;
+  onChange: (newValue: T) => void;
   timeThreshold: number;
 }) {
   const handleChange = usePreservedCallback(onChange);
-  const ref = useRef({ value: false, clearPreviousDebounce: () => {} });
+  const ref = useRef<{ value: T | typeof NOT_INVOKED; clearPreviousDebounce: () => void }>({
+    value: NOT_INVOKED,
+    clearPreviousDebounce: () => {},
+  });
 
   useEffect(function clearDebouncedOnUnmount() {
     const current = ref.current;
@@ -63,7 +85,7 @@ export function useDebouncedCallback({
   }, [leading, trailing]);
 
   return useCallback(
-    (nextValue: boolean) => {
+    (nextValue: T) => {
       if (nextValue === ref.current.value) {
         return;
       }

--- a/packages/react-simplikit/src/hooks/useImpressionRef/useImpressionRef.ts
+++ b/packages/react-simplikit/src/hooks/useImpressionRef/useImpressionRef.ts
@@ -52,10 +52,21 @@ export function useImpressionRef<Element extends HTMLElement>({
   const impressionEndHandler = usePreservedCallback(onImpressionEnd);
 
   const isIntersectingRef = useRef(false);
+  // An element that was never impressed can still report `false` (it starts outside the viewport,
+  // or the tab is hidden before it ever intersects); an end without a start must not be emitted.
+  const hasImpressionStartedRef = useRef(false);
   const impressionEventHandler = useDebouncedCallback({
     timeThreshold,
-    onChange: impressed => {
-      (impressed ? impressionStartHandler : impressionEndHandler)();
+    onChange: (impressed: boolean) => {
+      if (impressed) {
+        hasImpressionStartedRef.current = true;
+        impressionStartHandler();
+        return;
+      }
+
+      if (hasImpressionStartedRef.current) {
+        impressionEndHandler();
+      }
     },
     leading: true,
   });

--- a/packages/react-simplikit/src/hooks/useThrottledCallback/ko/useThrottledCallback.md
+++ b/packages/react-simplikit/src/hooks/useThrottledCallback/ko/useThrottledCallback.md
@@ -1,45 +1,41 @@
 # useThrottledCallback
 
-제공된 콜백 함수의 스로틀링된 버전을 반환하는 React 훅이에요. 스로틀링된 콜백은 지정된 간격당 최대 한 번만 호출돼요.
+`useThrottledCallback`는 제공된 콜백 함수의 스로틀링된 버전을 반환하는 리액트 훅이에요. 스로틀링된 콜백은 지정된 간격당 최대 한 번만 호출돼요.
 
 ## 인터페이스
 
 ```ts
-function useThrottledCallback<F extends (...args: any[]) => any>(
-  callback: F,
-  wait: number,
-  options?: { edges?: Array<'leading' | 'trailing'> }
-): F & { cancel: () => void };
+function useThrottledCallback<T>(options: Object): (nextValue: T) => void;
 ```
 
 ### 파라미터
 
 <Interface
   required
-  name="callback"
-  type="F"
-  description="스로틀링할 함수예요."
-/>
-
-<Interface
-  required
-  name="wait"
-  type="number"
-  description="호출을 스로틀링할 밀리초의 수예요."
-/>
-
-<Interface
   name="options"
-  type="{ edges?: Array<'leading' | 'trailing'> }"
-  description="스로틀의 동작을 제어하기 위한 옵션이에요."
+  type="Object"
+  description="옵션 객체예요."
   :nested="[
+    {
+      name: 'options.onChange',
+      type: '(newValue: T) => void',
+      required: true,
+      description:
+        '스로틀링할 콜백이에요. 마지막으로 전달된 값과 같은 값으로 호출하면 건너뛰어요.',
+    },
+    {
+      name: 'options.timeThreshold',
+      type: 'number',
+      required: true,
+      description: '호출을 스로틀링할 밀리초(ms)이에요.',
+    },
     {
       name: 'options.edges',
       type: 'Array<\'leading\' | \'trailing\'>',
       required: false,
       defaultValue: '[\'leading\', \'trailing\']',
       description:
-        '함수가 시작점, 끝점 또는 둘 다에서 호출될지 여부를 지정하는 선택적 배열이에요. <br />: 초기값은 <code>[\'leading\', \'trailing\']</code>이에요.',
+        '함수가 시작점, 끝점 또는 둘 다에서 호출될지 여부를 지정하는 선택적 배열이에요.',
     },
   ]"
 />
@@ -48,18 +44,27 @@ function useThrottledCallback<F extends (...args: any[]) => any>(
 
 <Interface
   name=""
-  type="F & { cancel: () => void }"
-  description="보류 중인 호출을 취소하는 <code>cancel</code> 메서드가 있는 스로틀링된 함수가 반환돼요."
+  type="(nextValue: T) => void"
+  description="간격당 최대 한 번 값을 <code>onChange</code>에 전달하는 스로틀링된 함수예요."
 />
 
 ## 예시
 
 ```tsx
-function SearchInput() {
-  const throttledSearch = useThrottledCallback((query: string) => {
-    console.log('검색어:', query);
-  }, 300);
+import { useThrottledCallback } from 'react-simplikit';
+import { useState } from 'react';
 
-  return <input onChange={e => throttledSearch(e.target.value)} />;
+function ScrollPosition() {
+  const [scrollTop, setScrollTop] = useState(0);
+  const setScrollTopThrottled = useThrottledCallback({
+    onChange: setScrollTop,
+    timeThreshold: 200,
+  });
+
+  return (
+    <div onScroll={e => setScrollTopThrottled(e.currentTarget.scrollTop)}>
+      <p>{scrollTop}px 스크롤됨</p>
+    </div>
+  );
 }
 ```

--- a/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.md
+++ b/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.md
@@ -5,7 +5,7 @@
 ## Interface
 
 ```ts
-function useThrottledCallback(options: Object): Function;
+function useThrottledCallback<T>(options: Object): (nextValue: T) => void;
 ```
 
 ### Parameters
@@ -18,9 +18,10 @@ function useThrottledCallback(options: Object): Function;
   :nested="[
     {
       name: 'options.onChange',
-      type: 'Function',
+      type: '(newValue: T) => void',
       required: true,
-      description: 'The callback function to throttle.',
+      description:
+        'The callback to throttle. A call with the same value as the last forwarded one is skipped.',
     },
     {
       name: 'options.timeThreshold',
@@ -43,18 +44,27 @@ function useThrottledCallback(options: Object): Function;
 
 <Interface
   name=""
-  type="Function"
-  description="throttled function that limits invoking the callback."
+  type="(nextValue: T) => void"
+  description="throttled function that forwards the value to <code>onChange</code> at most once per interval."
 />
 
 ## Example
 
 ```tsx
-function ScrollTracker() {
-  const throttledScroll = useThrottledCallback({
-    onChange: (scrollY: number) => console.log(scrollY),
+import { useThrottledCallback } from 'react-simplikit';
+import { useState } from 'react';
+
+function ScrollPosition() {
+  const [scrollTop, setScrollTop] = useState(0);
+  const setScrollTopThrottled = useThrottledCallback({
+    onChange: setScrollTop,
     timeThreshold: 200,
   });
-  return <div onScroll={e => throttledScroll(e.currentTarget.scrollTop)} />;
+
+  return (
+    <div onScroll={e => setScrollTopThrottled(e.currentTarget.scrollTop)}>
+      <p>Scrolled {scrollTop}px</p>
+    </div>
+  );
 }
 ```

--- a/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.spec.ts
+++ b/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.spec.ts
@@ -97,6 +97,16 @@ describe('useThrottledCallback', () => {
     expect(onChange).toBeCalledTimes(1);
   });
 
+  it('forwards a number value to onChange', () => {
+    const onChange = vi.fn<(value: number) => void>();
+    const { result } = renderHookSSR(() => useThrottledCallback({ onChange, timeThreshold: 100 }));
+
+    result.current(120);
+
+    expect(onChange).toBeCalledTimes(1);
+    expect(onChange).toBeCalledWith(120);
+  });
+
   it('should invoke the callback when the first value is false', () => {
     const onChange = vi.fn();
     const { result } = renderHookSSR(() => useThrottledCallback({ onChange, timeThreshold: 100 }));

--- a/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.ts
+++ b/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.ts
@@ -22,32 +22,39 @@ const NOT_INVOKED = Symbol('NOT_INVOKED');
  * `useThrottledCallback` is a React hook that returns a throttled version of the provided callback function.
  * The throttled callback will only be invoked at most once per specified interval.
  *
+ * @template T - The type of the value passed to `onChange`.
  * @param {Object} options - The options object.
- * @param {Function} options.onChange - The callback function to throttle.
+ * @param {(newValue: T) => void} options.onChange - The callback to throttle. A call with the same value as the last forwarded one is skipped.
  * @param {number} options.timeThreshold - The number of milliseconds to throttle invocations to.
  * @param {Array<'leading' | 'trailing'>} [options.edges=['leading', 'trailing']] - An optional array specifying whether the function should be invoked on the leading edge, trailing edge, or both.
  *
- * @returns {Function} A throttled function that limits invoking the callback.
+ * @returns {(nextValue: T) => void} A throttled function that forwards the value to `onChange` at most once per interval.
  *
  * @example
- * function ScrollTracker() {
- *   const throttledScroll = useThrottledCallback({
- *     onChange: (scrollY: number) => console.log(scrollY),
- *     timeThreshold: 200,
- *   });
- *   return <div onScroll={(e) => throttledScroll(e.currentTarget.scrollTop)} />;
+ * import { useThrottledCallback } from 'react-simplikit';
+ * import { useState } from 'react';
+ *
+ * function ScrollPosition() {
+ *   const [scrollTop, setScrollTop] = useState(0);
+ *   const setScrollTopThrottled = useThrottledCallback({ onChange: setScrollTop, timeThreshold: 200 });
+ *
+ *   return (
+ *     <div onScroll={e => setScrollTopThrottled(e.currentTarget.scrollTop)}>
+ *       <p>Scrolled {scrollTop}px</p>
+ *     </div>
+ *   );
  * }
  */
-export function useThrottledCallback({
+export function useThrottledCallback<T>({
   onChange,
   timeThreshold,
   edges = ['leading', 'trailing'],
 }: ThrottleOptions & {
-  onChange: (newValue: boolean) => void;
+  onChange: (newValue: T) => void;
   timeThreshold: number;
 }) {
   const handleChange = usePreservedCallback(onChange);
-  const ref = useRef<{ value: boolean | typeof NOT_INVOKED; clearPreviousThrottle: () => void }>({
+  const ref = useRef<{ value: T | typeof NOT_INVOKED; clearPreviousThrottle: () => void }>({
     value: NOT_INVOKED,
     clearPreviousThrottle: () => {},
   });
@@ -62,7 +69,7 @@ export function useThrottledCallback({
   const preservedEdges = usePreservedReference(edges);
 
   return useCallback(
-    (nextValue: boolean) => {
+    (nextValue: T) => {
       if (nextValue === ref.current.value) {
         return;
       }


### PR DESCRIPTION
## What

`useDebouncedCallback` and `useThrottledCallback` were typed to accept only a boolean (`onChange: (newValue: boolean) => void`), while their own examples passed a string and a number. Nothing in the implementation depends on the value being a boolean — the hooks debounce or throttle a setter and skip a value equal to the last one forwarded — so the type is now generic: `onChange: (newValue: T) => void`.

- Both hooks take a type parameter `T`, inferred from `onChange`. Boolean callers are unchanged.
- `useDebouncedCallback` no longer drops a first call of `false`. It seeded its "last forwarded value" with `false`, so the very first `false` looked redundant; it now starts from a sentinel, as #404 did for `useThrottledCallback`. A `false` that arrives while an initial `true` is still pending now replaces it — the settled value wins, which is what a debounced setter is expected to do.
- `useImpressionRef` (the internal consumer) relied on that swallowed `false` to avoid emitting `onImpressionEnd` for an element that was never impressed. It now tracks whether an impression started and only emits an end after a start.
- Tests: a string through `useDebouncedCallback`, a number through `useThrottledCallback`, and the first-`false` case. The existing debounce test that encoded the old seed behaviour is updated.
- Docs regenerated. The examples are now a debounced search input and a throttled scroll position, and both type-check. The Korean page for `useThrottledCallback` described a signature the hook never had (`useThrottledCallback(fn, 300)`) and is rewritten.
- The skill's "common needs" table lists both hooks again; they were removed in #441 because of this issue.
- Changeset: minor.

This continues #267 by @wo-o29, which proposed the same generic type for `useDebouncedCallback`. That branch predates the `packages/core` → `packages/react-simplikit` move and could not be rebased, so the change is re-applied here with the sentinel from #404 instead of a `null` seed and extended to `useThrottledCallback`. Credited as co-author on the commit.
