### PR TITLE
fix(useDebouncedCallback, useThrottledCallback): cancel the pending call when returning to the last forwarded value

### DIFF
--- a/.changeset/debounced-callback-stale-pending.md
+++ b/.changeset/debounced-callback-stale-pending.md
@@ -1,0 +1,5 @@
+---
+'react-simplikit': patch
+---
+
+`useDebouncedCallback` no longer forwards a stale value when the caller returns to the last forwarded one. Calling it with `'seo'` and then `'seoul'` right after `'seoul'` had already been forwarded used to skip the second call as a duplicate without cancelling the pending `'seo'`, so `onChange('seo')` fired anyway. The pending call is now cancelled first.

--- a/.changeset/debounced-callback-stale-pending.md
+++ b/.changeset/debounced-callback-stale-pending.md
@@ -2,4 +2,4 @@
 'react-simplikit': patch
 ---
 
-`useDebouncedCallback` no longer forwards a stale value when the caller returns to the last forwarded one. Calling it with `'seo'` and then `'seoul'` right after `'seoul'` had already been forwarded used to skip the second call as a duplicate without cancelling the pending `'seo'`, so `onChange('seo')` fired anyway. The pending call is now cancelled first.
+`useDebouncedCallback` and `useThrottledCallback` no longer forward a stale value when the caller returns to the last forwarded one. Calling with `'seo'` and then `'seoul'` right after `'seoul'` had already been forwarded used to skip the second call as a duplicate without cancelling the pending `'seo'`, so `onChange('seo')` fired anyway. The pending call is now cancelled first. For `useThrottledCallback` this only showed with `edges: ['trailing']`; the default leading edge forwards the intermediate value immediately and masked it.

--- a/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.spec.ts
+++ b/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.spec.ts
@@ -93,6 +93,22 @@ describe('useDebouncedCallback', () => {
     expect(onChange).toBeCalledWith(false);
   });
 
+  it('discards a pending value when the caller returns to the last forwarded one', () => {
+    const onChange = vi.fn();
+    const { result } = renderHookSSR(() => useDebouncedCallback({ onChange, timeThreshold: 100 }));
+
+    result.current('seoul');
+    vi.advanceTimersByTime(100);
+    expect(onChange).toHaveBeenLastCalledWith('seoul');
+
+    // 'seo' is scheduled, then the caller types back to 'seoul' before it fires
+    result.current('seo');
+    result.current('seoul');
+    vi.advanceTimersByTime(100);
+
+    expect(onChange).toBeCalledTimes(1);
+  });
+
   it('should cleanup on unmount', async () => {
     const onChange = vi.fn();
     const { result, unmount } = await renderHookSSR(() => useDebouncedCallback({ onChange, timeThreshold: 100 }));

--- a/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.ts
+++ b/packages/react-simplikit/src/hooks/useDebouncedCallback/useDebouncedCallback.ts
@@ -86,6 +86,8 @@ export function useDebouncedCallback<T>({
 
   return useCallback(
     (nextValue: T) => {
+      ref.current.clearPreviousDebounce();
+
       if (nextValue === ref.current.value) {
         return;
       }
@@ -99,8 +101,6 @@ export function useDebouncedCallback<T>({
         timeThreshold,
         { edges }
       );
-
-      ref.current.clearPreviousDebounce();
 
       debounced();
 

--- a/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.spec.ts
+++ b/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.spec.ts
@@ -130,6 +130,22 @@ describe('useThrottledCallback', () => {
     expect(onChange).toBeCalledTimes(1);
   });
 
+  it('discards a pending trailing value when the caller returns to the last forwarded one', () => {
+    const onChange = vi.fn();
+    const { result } = renderHookSSR(() => useThrottledCallback({ onChange, timeThreshold: 100, edges: ['trailing'] }));
+
+    result.current('seoul');
+    vi.advanceTimersByTime(100);
+    expect(onChange).toHaveBeenLastCalledWith('seoul');
+
+    // 'seo' is scheduled on the trailing edge, then the caller types back to 'seoul' before it fires
+    result.current('seo');
+    result.current('seoul');
+    vi.advanceTimersByTime(100);
+
+    expect(onChange).toBeCalledTimes(1);
+  });
+
   it('should handle value toggling', () => {
     const onChange = vi.fn();
     const { result } = renderHookSSR(() => useThrottledCallback({ onChange, timeThreshold: 100 }));

--- a/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.ts
+++ b/packages/react-simplikit/src/hooks/useThrottledCallback/useThrottledCallback.ts
@@ -70,6 +70,8 @@ export function useThrottledCallback<T>({
 
   return useCallback(
     (nextValue: T) => {
+      ref.current.clearPreviousThrottle();
+
       if (nextValue === ref.current.value) {
         return;
       }
@@ -83,8 +85,6 @@ export function useThrottledCallback<T>({
         timeThreshold,
         { edges: preservedEdges }
       );
-
-      ref.current.clearPreviousThrottle();
 
       throttled();
 


### PR DESCRIPTION
## Problem

Both `useDebouncedCallback` and `useThrottledCallback` skip a call whose value equals the last forwarded one — but they did so **before** cancelling the pending call, so a call for a *different* value scheduled in between survived and fired.

```ts
const search = useDebouncedCallback({ onChange: fetchResults, timeThreshold: 300 });

search('seoul');   // 300ms later → fetchResults('seoul')   ✓
search('seo');     // user deletes two chars → 'seo' scheduled
search('seoul');   // user types them back  → equals last forwarded, early return
                   //                          'seo' timer is NOT cancelled
                   // 300ms later → fetchResults('seo')      ✗  input shows 'seoul'
```

`useThrottledCallback` has the same ordering. With the default `edges` the leading edge forwards `'seo'` immediately and updates the compared value, so the third call is not a duplicate and the defect is masked. With `edges: ['trailing']` it reproduces exactly as above.

The comparison has been first in both callbacks since #90; #446 changed the type but not this ordering.

## Fix

Move `clearPreviousDebounce()` / `clearPreviousThrottle()` above the dedupe check. Cancelling was already unconditional on every non-duplicate call, so the only behaviour change is that a duplicate call now also cancels whatever was pending.

## Tests

One new test per hook, `discards a pending (trailing) value when the caller returns to the last forwarded one`. Each fails on `main` (`onChange` called 2 times, second with `'seo'`) and passes with the fix. All 521 tests pass, coverage stays at 100%.

## Changeset

`patch` — behaviour fix, no API change.
