### PR TITLE
fix(getSafeAreaInset): re-export the SafeAreaInset type from the package root

### DIFF
--- a/.changeset/root-safe-area-inset-type.md
+++ b/.changeset/root-safe-area-inset-type.md
@@ -1,0 +1,5 @@
+---
+'react-simplikit': patch
+---
+
+Re-export the `SafeAreaInset` type from the package root. `@react-simplikit/mobile` exported it, but it was dropped when that package was absorbed into the root entry, leaving `import type { SafeAreaInset }` with no replacement.

--- a/packages/react-simplikit/src/index.ts
+++ b/packages/react-simplikit/src/index.ts
@@ -53,7 +53,7 @@ export { useVisualViewport } from './mobile/hooks/useVisualViewport/index.ts';
 export { disableBodyScrollLock } from './mobile/utils/disableBodyScrollLock/index.ts';
 export { enableBodyScrollLock } from './mobile/utils/enableBodyScrollLock/index.ts';
 export { getKeyboardHeight } from './mobile/utils/getKeyboardHeight/index.ts';
-export { getSafeAreaInset } from './mobile/utils/getSafeAreaInset/index.ts';
+export { getSafeAreaInset, type SafeAreaInset } from './mobile/utils/getSafeAreaInset/index.ts';
 export { isAndroid } from './mobile/utils/isAndroid/index.ts';
 export { isIOS } from './mobile/utils/isIOS/index.ts';
 export { isKeyboardVisible } from './mobile/utils/isKeyboardVisible/index.ts';


### PR DESCRIPTION
# Overview

Closes #453. `@react-simplikit/mobile` exported `type SafeAreaInset`. The absorption in #437 moved every other export of that package to the root barrel but left this one behind, so it is the only symbol of the old package with no root equivalent — `import type { SafeAreaInset } from '@react-simplikit/mobile'` has nothing to migrate to.

```ts
import { getSafeAreaInset, type SafeAreaInset } from 'react-simplikit';
```

One line in `src/index.ts`. The leaf barrel `src/mobile/utils/getSafeAreaInset/index.ts:1` already exported the type, so nothing below the root needed touching.

## Checklist

- [ ] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
