### PR TITLE
fix(codemod): preserve one-per-line imports when merging and point at the formatter after a run

### DIFF
--- a/.changeset/codemod-multiline-merge.md
+++ b/.changeset/codemod-multiline-merge.md
@@ -1,0 +1,5 @@
+---
+'react-simplikit-codemod': patch
+---
+
+`mobile-to-root` keeps one binding per line when it folds imports into a `react-simplikit` import that is already written that way, instead of appending them all to the last line. The closing message and the README now say to run your formatter or linter fix on the changed files: import-order rules place `react-simplikit` differently from `@react-simplikit/mobile`, so a sorted import block is usually out of order after the run.

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -73,4 +73,6 @@ npm install
 
 The codemod already wrote the dependency and its version range, so a bare reinstall is enough — `npm install react-simplikit` would overwrite that range with whatever is newest.
 
+Then run your formatter or linter fix on the changed files. The specifier moved from `@react-simplikit/mobile` to `react-simplikit`, and import-order rules such as `import/order` or `simple-import-sort` place the two differently, so an import that was sorted before the run is usually out of order after it.
+
 One import needs a version floor: `SafeAreaInset` is only re-exported from the root entry in `react-simplikit@0.2.0` and later. An existing range below that floor is raised; a `workspace:`, `catalog:` or `file:` protocol is kept as-is and reported instead, since only you know what it should point at.

--- a/packages/codemod/src/formatHuman.test.ts
+++ b/packages/codemod/src/formatHuman.test.ts
@@ -49,6 +49,17 @@ describe('formatHuman', () => {
 
     expect(output).toContain('Imports now resolve from react-simplikit');
     expect(output).toContain(MIN_RUNTIME_VERSION);
+    expect(output).toContain('import-order rules place react-simplikit differently');
+  });
+
+  it('skips the lint hint when only package.json changed', () => {
+    const output = formatHuman(
+      { scanned: 1, changed: [{ kind: 'manifest', file: 'package.json', dependencies: [] }], manual: [], failed: [] },
+      false
+    );
+
+    expect(output).toContain('Imports now resolve');
+    expect(output).not.toContain('import-order');
   });
 
   it('does not claim a dry run changed anything', () => {
@@ -57,6 +68,7 @@ describe('formatHuman', () => {
     expect(output).toContain('Nothing was written');
     expect(output).toContain('Run without --dry-run to apply');
     expect(output).not.toContain('Imports now resolve');
+    expect(output).not.toContain('import-order');
   });
 
   it('reports a clean run without a version reminder or a file list', () => {

--- a/packages/codemod/src/formatHuman.ts
+++ b/packages/codemod/src/formatHuman.ts
@@ -55,6 +55,12 @@ export function formatHuman(result: RunResult, dryRun: boolean): string {
     );
   }
 
+  if (!dryRun && changed.some(file => file.kind === 'source')) {
+    lines.push(
+      `Then run your formatter or linter fix on the changed files: import-order rules place ${ROOT_PACKAGE_NAME} differently from ${MOBILE_PACKAGE_NAME}.`
+    );
+  }
+
   return lines.join('\n');
 }
 

--- a/packages/codemod/src/mobileToRoot/mergeImports.ts
+++ b/packages/codemod/src/mobileToRoot/mergeImports.ts
@@ -97,16 +97,31 @@ function losesComment(sourceFile: ts.SourceFile, statement: ts.Statement): boole
   return false;
 }
 
+function elementSeparator(sourceFile: ts.SourceFile, last: ts.ImportSpecifier): string {
+  const { text } = sourceFile;
+  const lastStart = last.getStart(sourceFile);
+  const lead = text.slice(text.lastIndexOf('\n', lastStart - 1) + 1, lastStart);
+
+  return lead.trim() === '' ? `,\n${lead}` : ', ';
+}
+
 function insertIntoNamedImports(
   sourceFile: ts.SourceFile,
   named: ts.NamedImports,
   appended: readonly string[]
 ): Splice {
   const last = named.elements.at(-1);
-  const position = last === undefined ? named.getStart(sourceFile) + 1 : last.getEnd();
-  const text = last === undefined ? appended.join(', ') : `, ${appended.join(', ')}`;
 
-  return { start: position, end: position, text };
+  if (last === undefined) {
+    const position = named.getStart(sourceFile) + 1;
+
+    return { start: position, end: position, text: appended.join(', ') };
+  }
+
+  const separator = elementSeparator(sourceFile, last);
+  const position = last.getEnd();
+
+  return { start: position, end: position, text: `${separator}${appended.join(separator)}` };
 }
 
 export function buildMergeSplices(sourceFile: ts.SourceFile, hits: readonly SpecifierHit[]): MergeResult {

--- a/packages/codemod/src/mobileToRoot/transformSource.test.ts
+++ b/packages/codemod/src/mobileToRoot/transformSource.test.ts
@@ -191,6 +191,55 @@ describe('transformSource — merging with an existing react-simplikit import', 
     );
   });
 
+  it('keeps one binding per line when the target list is written that way', () => {
+    const withTrailingComma = [
+      `import {`,
+      `  useDebounce,`,
+      `  useLoading,`,
+      `} from 'react-simplikit';`,
+      `import { isIOS, useKeyboardHeight } from '@react-simplikit/mobile';`,
+      ``,
+    ].join('\n');
+
+    expect(transformSource(withTrailingComma, 'a.ts').code).toBe(
+      [
+        `import {`,
+        `  useDebounce,`,
+        `  useLoading,`,
+        `  isIOS,`,
+        `  useKeyboardHeight,`,
+        `} from 'react-simplikit';`,
+        ``,
+      ].join('\n')
+    );
+
+    const withoutTrailingComma = [
+      `import {`,
+      `\tuseLoading`,
+      `} from 'react-simplikit';`,
+      `import { isIOS } from '@react-simplikit/mobile';`,
+      ``,
+    ].join('\n');
+
+    expect(transformSource(withoutTrailingComma, 'a.ts').code).toBe(
+      [`import {`, `\tuseLoading,`, `\tisIOS`, `} from 'react-simplikit';`, ``].join('\n')
+    );
+  });
+
+  it('stays inline when the bindings share a line under a broken-out brace', () => {
+    const input = [
+      `import {`,
+      `  useDebounce, useLoading`,
+      `} from 'react-simplikit';`,
+      `import { isIOS } from '@react-simplikit/mobile';`,
+      ``,
+    ].join('\n');
+
+    expect(transformSource(input, 'a.ts').code).toBe(
+      [`import {`, `  useDebounce, useLoading, isIOS`, `} from 'react-simplikit';`, ``].join('\n')
+    );
+  });
+
   it('fills an empty named list on the target', () => {
     const input = [`import {} from 'react-simplikit';`, `import { isIOS } from '@react-simplikit/mobile';`, ``].join(
       '\n'

--- a/packages/plugin/skills/react-simplikit-codemod/SKILL.md
+++ b/packages/plugin/skills/react-simplikit-codemod/SKILL.md
@@ -105,7 +105,8 @@ The object always carries these six keys.
 
 1. Act on every entry in `manual` by hand. Entries with a `line` mark an import the codemod deliberately left on its own — read the reason before merging it yourself, because merging it by hand can change what a name binds.
 2. Run a bare `npm install` (or the equivalent) so the lockfile drops the old package. Do not run `npm install react-simplikit` — it would overwrite the range the codemod just wrote.
-3. Require `react-simplikit@0.2.0` or newer — the first release re-exporting the `SafeAreaInset` type from the root entry. An existing range below that floor is raised automatically; a `workspace:`/`catalog:`/`file:` protocol is kept and reported instead.
+3. Run the project's formatter or linter fix (`eslint --fix`, say) on the changed files. Import-order rules place `react-simplikit` differently from `@react-simplikit/mobile`, so a sorted import block is usually out of order after the run.
+4. Require `react-simplikit@0.2.0` or newer — the first release re-exporting the `SafeAreaInset` type from the root entry. An existing range below that floor is raised automatically; a `workspace:`/`catalog:`/`file:` protocol is kept and reported instead.
 
 ## Failure handling
 


### PR DESCRIPTION
# Overview

Two things `mobile-to-root` got wrong on a real monorepo run.

Merging into a `react-simplikit` import written one binding per line appended every new binding to the last line:

```ts
import {
  useDebounce,
  useLoading, getSafeAreaInset, useKeyboardHeight,
} from 'react-simplikit';
```

The separator now follows the target: a binding that starts its own line gets a newline and its indent, a binding that shares a line stays inline.

Every rewritten file then failed the repo's `import-x/order` rule, because `react-simplikit` sorts after `react` where `@react-simplikit/mobile` sorted among the scoped packages. The closing line, the README and the skill now say to run the formatter or linter fix on the changed files. The codemod leaves formatting untouched by design, so it points at the tool that owns it instead of re-sorting imports itself.

## Verification

- 131 unit tests at 100% coverage, plus the 24 e2e tests that spawn the built bin
- The built bin run against a monorepo rewrote 7 files, found nothing on a second run, and `eslint --fix` cleared the remaining import-order errors

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc? — bin-only package, no public API surface
