### PR TITLE
docs: point the README and the mobile installation guide at the mobile-to-root codemod

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -12,7 +12,7 @@ Una colección de utilidades de React ligeras y sin dependencias para crear apli
 | --------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | [react-simplikit](./packages/react-simplikit) | Universal hooks - Hooks de estado y lógica más utilidades para la web móvil, todo desde una sola entrada | [![npm](https://img.shields.io/npm/v/react-simplikit.svg)](https://www.npmjs.com/package/react-simplikit) |
 
-> **Nota**: todos los Hooks se distribuyen desde la única entrada `react-simplikit`, incluidas las utilidades para la web móvil (viewport, keyboard, scroll). Esto sustituye al paquete obsoleto `@react-simplikit/mobile`. Los Hooks solo tocan las APIs del navegador dentro de su cuerpo, así que importar desde la raíz sigue siendo seguro en React Native y en SSR.
+> **Nota**: todos los Hooks se distribuyen desde la única entrada `react-simplikit`, incluidas las utilidades para la web móvil (viewport, keyboard, scroll). Esto sustituye al paquete obsoleto `@react-simplikit/mobile`. Para migrar una base de código existente, ejecuta `npx react-simplikit-codemod mobile-to-root`. Los Hooks solo tocan las APIs del navegador dentro de su cuerpo, así que importar desde la raíz sigue siendo seguro en React Native y en SSR.
 
 ## Características
 
@@ -25,7 +25,6 @@ Una colección de utilidades de React ligeras y sin dependencias para crear apli
 ## Instalación
 
 ```bash
-# Una sola instalación cubre tanto los Hooks de la raíz como la subruta de móvil
 npm install react-simplikit
 ```
 

--- a/README-ja_jp.md
+++ b/README-ja_jp.md
@@ -12,7 +12,7 @@
 | --------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
 | [react-simplikit](./packages/react-simplikit) | Universal hooks - 状態/ロジック用フックとモバイル Web ユーティリティを単一のエントリで提供 | [![npm](https://img.shields.io/npm/v/react-simplikit.svg)](https://www.npmjs.com/package/react-simplikit) |
 
-> **注記**: すべてのフックは単一の `react-simplikit` エントリから提供されます — モバイル Web ユーティリティ（viewport、keyboard、scroll）も含みます。非推奨となった `@react-simplikit/mobile` パッケージを置き換えます。フックがブラウザ API に触れるのはインポート時ではなくフック本体の中だけなので、React Native や SSR でもルートからのインポートは安全です。
+> **注記**: すべてのフックは単一の `react-simplikit` エントリから提供されます — モバイル Web ユーティリティ（viewport、keyboard、scroll）も含みます。非推奨となった `@react-simplikit/mobile` パッケージを置き換えます。既存のコードベースを移行するには `npx react-simplikit-codemod mobile-to-root` を実行してください。フックがブラウザ API に触れるのはインポート時ではなくフック本体の中だけなので、React Native や SSR でもルートからのインポートは安全です。
 
 ## 特長
 
@@ -25,7 +25,6 @@
 ## インストール
 
 ```bash
-# 1 回のインストールで、ルート export のフックとモバイルサブパスの両方を利用できます
 npm install react-simplikit
 ```
 

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -12,7 +12,7 @@
 | --------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | [react-simplikit](./packages/react-simplikit) | Universal hooks - 상태/로직 훅과 모바일 웹 유틸리티를 하나의 진입점에서 제공 | [![npm](https://img.shields.io/npm/v/react-simplikit.svg)](https://www.npmjs.com/package/react-simplikit) |
 
-> **참고**: 모든 훅은 `react-simplikit` 단일 진입점에서 제공됩니다 — 모바일 웹 유틸리티(viewport, keyboard, scroll)도 포함해서요. 기존 `@react-simplikit/mobile` 패키지를 대체합니다. 훅은 브라우저 API를 임포트 시점이 아니라 훅 본문 안에서만 사용하므로, React Native와 SSR에서도 루트 임포트가 안전합니다.
+> **참고**: 모든 훅은 `react-simplikit` 단일 진입점에서 제공됩니다 — 모바일 웹 유틸리티(viewport, keyboard, scroll)도 포함해서요. 기존 `@react-simplikit/mobile` 패키지를 대체합니다. 기존 코드베이스는 `npx react-simplikit-codemod mobile-to-root`로 마이그레이션하세요. 훅은 브라우저 API를 임포트 시점이 아니라 훅 본문 안에서만 사용하므로, React Native와 SSR에서도 루트 임포트가 안전합니다.
 
 ## 특징
 
@@ -25,7 +25,6 @@
 ## 설치
 
 ```bash
-# One install covers both the root hooks and the mobile subpath
 npm install react-simplikit
 ```
 

--- a/README-zh_hans.md
+++ b/README-zh_hans.md
@@ -12,7 +12,7 @@
 | --------------------------------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
 | [react-simplikit](./packages/react-simplikit) | Universal hooks - 状态/逻辑 Hook 与移动端 Web 工具函数，都从单一入口提供 | [![npm](https://img.shields.io/npm/v/react-simplikit.svg)](https://www.npmjs.com/package/react-simplikit) |
 
-> **注意**：所有 Hook 都从单一的 `react-simplikit` 入口提供，其中也包括移动端 Web 工具函数（viewport、keyboard、scroll）。它取代了已弃用的 `@react-simplikit/mobile` 包。Hook 只在函数体内部才会触碰浏览器 API，因此从根入口导入在 React Native 和 SSR 中同样安全。
+> **注意**：所有 Hook 都从单一的 `react-simplikit` 入口提供，其中也包括移动端 Web 工具函数（viewport、keyboard、scroll）。它取代了已弃用的 `@react-simplikit/mobile` 包。要迁移现有代码库，请运行 `npx react-simplikit-codemod mobile-to-root`。Hook 只在函数体内部才会触碰浏览器 API，因此从根入口导入在 React Native 和 SSR 中同样安全。
 
 ## 特性
 
@@ -25,7 +25,6 @@
 ## 安装
 
 ```bash
-# 一次安装即可同时使用根入口的 Hook 和移动端子路径
 npm install react-simplikit
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A collection of lightweight, zero-dependency React utilities for building robust
 | --------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | [react-simplikit](./packages/react-simplikit) | Universal hooks - state/logic hooks plus mobile web utilities, all from one entry | [![npm](https://img.shields.io/npm/v/react-simplikit.svg)](https://www.npmjs.com/package/react-simplikit) |
 
-> **Note**: every hook ships from the single `react-simplikit` entry — mobile web utilities (viewport, keyboard, scroll) included. This replaces the deprecated `@react-simplikit/mobile` package. Hooks touch browser APIs only inside their bodies, so importing the root stays safe on React Native and SSR.
+> **Note**: every hook ships from the single `react-simplikit` entry — mobile web utilities (viewport, keyboard, scroll) included. This replaces the deprecated `@react-simplikit/mobile` package. To migrate an existing codebase, run `npx react-simplikit-codemod mobile-to-root`. Hooks touch browser APIs only inside their bodies, so importing the root stays safe on React Native and SSR.
 
 ## Features
 
@@ -25,7 +25,6 @@ A collection of lightweight, zero-dependency React utilities for building robust
 ## Installation
 
 ```bash
-# One install covers both the root hooks and the mobile subpath
 npm install react-simplikit
 ```
 

--- a/docs/es/mobile/installation.md
+++ b/docs/es/mobile/installation.md
@@ -40,3 +40,13 @@ import { useKeyboardHeight, useAvoidKeyboard } from 'react-simplikit';
 ```
 
 Todos los Hooks admiten tree shaking, así que en tu bundle solo se incluye lo que realmente usas.
+
+## Migrar desde `@react-simplikit/mobile`
+
+Todo lo que exportaba `@react-simplikit/mobile` ahora se distribuye desde `react-simplikit`. El codemod reescribe los imports y la dependencia de `package.json` directamente en tu proyecto:
+
+```sh
+npx react-simplikit-codemod mobile-to-root
+```
+
+Después, ejecuta tu formateador o el fix del linter sobre los archivos modificados: las reglas de orden de imports colocan `react-simplikit` en una posición distinta a la de `@react-simplikit/mobile`.

--- a/docs/ja/mobile/installation.md
+++ b/docs/ja/mobile/installation.md
@@ -40,3 +40,13 @@ import { useKeyboardHeight, useAvoidKeyboard } from 'react-simplikit';
 ```
 
 すべてのフックはツリーシェイキング対応なので、実際に使用するものだけがバンドルに含まれます。
+
+## `@react-simplikit/mobile` からの移行
+
+`@react-simplikit/mobile` が export していたものは、すべて `react-simplikit` から提供されるようになりました。codemod が import 文と `package.json` の依存関係をその場で書き換えます。
+
+```sh
+npx react-simplikit-codemod mobile-to-root
+```
+
+その後、変更されたファイルに対してフォーマッターまたはリンターの fix を実行してください。import の順序ルールでは `react-simplikit` と `@react-simplikit/mobile` の並ぶ位置が異なるからです。

--- a/docs/ko/mobile/installation.md
+++ b/docs/ko/mobile/installation.md
@@ -40,3 +40,13 @@ import { useKeyboardHeight, useAvoidKeyboard } from 'react-simplikit';
 ```
 
 모든 훅은 트리 쉐이킹이 가능하므로, 번들에는 사용하는 것만 포함돼요.
+
+## `@react-simplikit/mobile`에서 마이그레이션하기
+
+`@react-simplikit/mobile`이 export하던 것은 이제 모두 `react-simplikit`에서 제공돼요. codemod가 import 문과 `package.json`의 의존성을 파일에서 바로 고쳐 써요:
+
+```sh
+npx react-simplikit-codemod mobile-to-root
+```
+
+그다음 변경된 파일에 포매터나 린터 fix를 실행하세요. import 정렬 규칙이 `react-simplikit`과 `@react-simplikit/mobile`을 서로 다른 위치에 두기 때문이에요.

--- a/docs/mobile/installation.md
+++ b/docs/mobile/installation.md
@@ -40,3 +40,13 @@ import { useKeyboardHeight, useAvoidKeyboard } from 'react-simplikit';
 ```
 
 All hooks are tree-shakeable, so you only include what you use in your bundle.
+
+## Migrating from `@react-simplikit/mobile`
+
+Everything `@react-simplikit/mobile` exported now ships from `react-simplikit`. The codemod rewrites the imports and the `package.json` dependency in place:
+
+```sh
+npx react-simplikit-codemod mobile-to-root
+```
+
+Then run your formatter or linter fix on the changed files: import-order rules place `react-simplikit` differently from `@react-simplikit/mobile`.

--- a/docs/zh-Hans/mobile/installation.md
+++ b/docs/zh-Hans/mobile/installation.md
@@ -40,3 +40,13 @@ import { useKeyboardHeight, useAvoidKeyboard } from 'react-simplikit';
 ```
 
 所有 Hook 都支持 tree shaking，因此只有你真正用到的部分才会被打进包里。
+
+## 从 `@react-simplikit/mobile` 迁移
+
+`@react-simplikit/mobile` 导出的所有内容现在都由 `react-simplikit` 提供。codemod 会就地改写 import 语句和 `package.json` 中的依赖：
+
+```sh
+npx react-simplikit-codemod mobile-to-root
+```
+
+之后请对改动过的文件运行格式化工具或 linter 的 fix：import 排序规则会把 `react-simplikit` 和 `@react-simplikit/mobile` 放在不同的位置。


### PR DESCRIPTION
# Overview

Closes #461

`README.md:15` called `@react-simplikit/mobile` deprecated without saying how to leave it, and `docs/mobile/installation.md` had no migration section. The only place a consumer could find `npx react-simplikit-codemod mobile-to-root` was the llms.txt intro.

- The README note now names the command, in every locale.
- The install snippet no longer promises a "mobile subpath". There is none.
- The mobile installation guide gets a "Migrating from `@react-simplikit/mobile`" section with the command and the formatter hint from the codemod README, in every locale.

Refs #455 — the `npm deprecate` step stays there.

## Verification

- `yarn test:format` and `yarn test:docs` pass
- ko, ja, es and zh-Hans reviewed with the `translation-reviewer` agent

## Checklist

- [ ] Did you write the test code? — docs only
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line? — docs only
- [ ] Did you write the JSDoc? — docs only
