### PR TITLE
chore(ci): align the verify-compiler job with the action pins used by the other jobs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -423,13 +423,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'


### PR DESCRIPTION
# Overview

Closes #463

`verify-compiler` was the one job in `integration.yml` still on `actions/checkout` v6.0.3 and `actions/setup-node` v6.4.0. It now uses the v7.0.1 and v7.0.0 pins every other job uses, so the workflow has one version of each action to bump.

## Verification

- Only the two `uses:` lines of the job change
- `yarn test:format` and `yarn test:docs` pass (`verifyDocsI18n.ts` asserts on this workflow)

## Checklist

- [ ] Did you write the test code? — workflow only
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line? — workflow only
- [ ] Did you write the JSDoc? — workflow only
