### PR TITLE
feat(useInputState): support lazy initialization for initial value

### DIFF
--- a/.changeset/six-goats-nail.md
+++ b/.changeset/six-goats-nail.md
@@ -1,0 +1,5 @@
+---
+'react-simplikit': minor
+---
+
+Add lazy initializer support to useInputState.

--- a/packages/plugin/skills/react-simplikit/references/useInputState.md
+++ b/packages/plugin/skills/react-simplikit/references/useInputState.md
@@ -6,7 +6,7 @@
 
 ```ts
 function useInputState(
-  initialValue: string = '',
+  initialValue: string | (() => string) = '',
   transformValue: (value: string) => string = (v: string) => v
 ): [
   value: string,
@@ -18,7 +18,7 @@ function useInputState(
 
 <Interface
   name="initialValue"
-  type="string"
+  type="string | (() => string)"
   description='The initial value of the input. Defaults to an empty string (<code>""</code>).'
 />
 

--- a/packages/react-simplikit/src/hooks/useInputState/ko/useInputState.md
+++ b/packages/react-simplikit/src/hooks/useInputState/ko/useInputState.md
@@ -6,7 +6,7 @@
 
 ```ts
 function useInputState(
-  initialValue: string = '',
+  initialValue: string | (() => string) = '',
   transformValue: (value: string) => string = (v: string) => v
 ): [
   value: string,
@@ -18,7 +18,7 @@ function useInputState(
 
 <Interface
   name="initialValue"
-  type="string"
+  type="string | (() => string)"
   description='입력의 초기 값이에요. 기본값은 빈 문자열(<code>""</code>)이에요.'
 />
 

--- a/packages/react-simplikit/src/hooks/useInputState/useInputState.md
+++ b/packages/react-simplikit/src/hooks/useInputState/useInputState.md
@@ -6,7 +6,7 @@
 
 ```ts
 function useInputState(
-  initialValue: string = '',
+  initialValue: string | (() => string) = '',
   transformValue: (value: string) => string = (v: string) => v
 ): [
   value: string,
@@ -18,7 +18,7 @@ function useInputState(
 
 <Interface
   name="initialValue"
-  type="string"
+  type="string | (() => string)"
   description='The initial value of the input. Defaults to an empty string (<code>""</code>).'
 />
 

--- a/packages/react-simplikit/src/hooks/useInputState/useInputState.spec.ts
+++ b/packages/react-simplikit/src/hooks/useInputState/useInputState.spec.ts
@@ -44,36 +44,36 @@ describe('useInputState', () => {
     const { result: result2 } = await renderHookSSR(() => useInputState('other-value'));
     expect(result2.current[0]).toBe('other-value');
   });
-});
 
-it('should update value when change event occurs', async () => {
-  const { getByRole } = render(createElement(createTestInput()));
-  const input = getByRole('textbox');
+  it('should update value when change event occurs', async () => {
+    const { getByRole } = render(createElement(createTestInput()));
+    const input = getByRole('textbox');
 
-  expect(input).toHaveValue('');
+    expect(input).toHaveValue('');
 
-  fireEvent.change(input, { target: { value: 'changed' } });
-  expect(input).toHaveValue('changed');
+    fireEvent.change(input, { target: { value: 'changed' } });
+    expect(input).toHaveValue('changed');
 
-  fireEvent.change(input, { target: { value: 'one more changed' } });
-  expect(input).toHaveValue('one more changed');
-});
+    fireEvent.change(input, { target: { value: 'one more changed' } });
+    expect(input).toHaveValue('one more changed');
+  });
 
-it('should transform value according to the provided function', async () => {
-  const { getByRole } = render(createElement(createTestInput('', v => v.toUpperCase())));
+  it('should transform value according to the provided function', async () => {
+    const { getByRole } = render(createElement(createTestInput('', v => v.toUpperCase())));
 
-  const input = getByRole('textbox');
-  fireEvent.change(input, { target: { value: 'must be uppercase' } });
+    const input = getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'must be uppercase' } });
 
-  expect(input).toHaveValue('MUST BE UPPERCASE');
-});
+    expect(input).toHaveValue('MUST BE UPPERCASE');
+  });
 
-it('should update value when change event occurs on a textarea', async () => {
-  const { getByRole } = render(createElement(createTestTextarea()));
-  const textarea = getByRole('textbox');
+  it('should update value when change event occurs on a textarea', async () => {
+    const { getByRole } = render(createElement(createTestTextarea()));
+    const textarea = getByRole('textbox');
 
-  expect(textarea).toHaveValue('');
+    expect(textarea).toHaveValue('');
 
-  fireEvent.change(textarea, { target: { value: 'changed' } });
-  expect(textarea).toHaveValue('changed');
+    fireEvent.change(textarea, { target: { value: 'changed' } });
+    expect(textarea).toHaveValue('changed');
+  });
 });

--- a/packages/react-simplikit/src/hooks/useInputState/useInputState.spec.ts
+++ b/packages/react-simplikit/src/hooks/useInputState/useInputState.spec.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { renderHookSSR } from '../../_internal/test-utils/renderHookSSR.tsx';
 
@@ -75,5 +75,21 @@ describe('useInputState', () => {
 
     fireEvent.change(textarea, { target: { value: 'changed' } });
     expect(textarea).toHaveValue('changed');
+  });
+
+  it('should initialize value using a lazy initializer', () => {
+    const { result } = renderHookSSR(() => useInputState(() => 'initial-value'));
+    const [value] = result.current;
+
+    expect(value).toBe('initial-value');
+  });
+
+  it('should call the lazy initializer only on initial render', () => {
+    const initializer = vi.fn(() => 'initial-value');
+    const { rerender } = renderHookSSR(() => useInputState(initializer));
+
+    rerender();
+
+    expect(initializer).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-simplikit/src/hooks/useInputState/useInputState.ts
+++ b/packages/react-simplikit/src/hooks/useInputState/useInputState.ts
@@ -2,12 +2,14 @@ import { ChangeEvent, ChangeEventHandler, useCallback, useState } from 'react';
 
 type InputLikeElement = HTMLInputElement | HTMLTextAreaElement;
 
+type InitialValue = string | (() => string);
+
 /**
  * @description
  * `useInputState` is a React hook that manages an input state with optional value transformation.
  * The returned `onChange` handler works with both `<input>` and `<textarea>` elements.
  *
- * @param {string} [initialValue=""] - The initial value of the input. Defaults to an empty string (`""`).
+ * @param {string | (() => string)} [initialValue=""] - The initial value of the input. Defaults to an empty string (`""`).
  * @param {(value: string) => string} [transformValue=(v: string) => v] - A function to transform the input value.
  *   Defaults to an identity function that returns the input unchanged.
  *
@@ -26,7 +28,7 @@ type InputLikeElement = HTMLInputElement | HTMLTextAreaElement;
  *   );
  * }
  */
-export function useInputState(initialValue = '', transformValue: (value: string) => string = echo) {
+export function useInputState(initialValue: InitialValue = '', transformValue: (value: string) => string = echo) {
   const [value, setValue] = useState(initialValue);
 
   const handleValueChange: ChangeEventHandler<InputLikeElement> = useCallback(


### PR DESCRIPTION
# Overview

<!-- A clear and concise description of what this PR is about. -->
useInputState is a custom hook built on top of React's useState. However, because the initialValue type was limited to string, it did not support the lazy initializer provided by useState.

This PR expands the initialValue type to accept string | (() => string), allowing the initial value to be computed lazily and avoiding unnecessary recalculation on re-renders.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
