### PR TITLE
docs(contributing): remove duplicate scaffolding and changeset guidance

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,29 +15,6 @@ For detailed instructions, see the package-specific guides:
 - [Core Package Contributing Guide](../docs/core/contributing.md)
 - [Mobile Package Contributing Guide](../docs/mobile/contributing.md)
 
-## Scaffolding
-
-Use the scaffold command to create a basic structure for new implementations:
-
-```bash
-yarn run scaffold <name> --type <type>
-```
-
-- `type`: `component`, `hook`, or `util` (shortcuts: `c`, `h`, `u`)
-- `name`: Name of the implementation
-
-## Creating a Changeset
-
-When your changes affect a package, create a changeset:
-
-```bash
-yarn changeset
-```
-
-Select the version bump type (`patch`, `minor`, or `major`).
-
-> **Note:** Both packages are currently in the `0.0.x` stage. During this phase, most changes should use `patch`. If you're unsure about the version type, please discuss with the maintainers.
-
 ## Useful Links
 
 - [Documentation Site](https://react-simplikit.slash.page)


### PR DESCRIPTION
# Overview

What do you think about removing the redundant content as shown here?
I think .github/CONTRIBUTING.md only needs to direct contributors to the detailed contribution guidelines for core and mobile. Repeating information already covered in those documents makes maintenance harder.
I also noticed that a new minor version was released recently, so some information in the changeset section was already outdated!
```
> **Note:** Both packages are currently in the `0.0.x` stage.
During this phase, most changes should use `patch`. If you're unsure about the version type, please discuss with the maintainers.
```

## Checklist

- [ ] Did you write the test code?
- [ ] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?
