### PR TITLE
fix(docs): link the Reference sidebar group to its index page

### DIFF
--- a/.scripts/verifyDocsI18n.ts
+++ b/.scripts/verifyDocsI18n.ts
@@ -285,6 +285,12 @@ assert.equal(rootConfig.themeConfig?.editLink?.text, 'Edit this page on GitHub')
 const rootSidebar = (rootConfig.themeConfig?.sidebar as Record<string, DefaultTheme.SidebarItem[]>)['/'];
 const referenceGroups = rootSidebar[1].items ?? [];
 
+assert.equal(
+  rootSidebar[1].link,
+  '/reference',
+  'the reference group must link its index page, otherwise VitePress computes its prev/next from the first sidebar entry'
+);
+
 assert.deepEqual(
   referenceGroups.map(group => group.text),
   ['Components', 'Hooks', 'Utils'],

--- a/.vitepress/libs/buildLocaleConfig.mts
+++ b/.vitepress/libs/buildLocaleConfig.mts
@@ -47,6 +47,7 @@ export function buildLocaleConfig(
           },
           {
             text: strings.referenceLabel,
+            link: `${prefix}/reference`,
             items: sortByText([
               { text: strings.componentsLabel, collapsed: false, items: components },
               { text: strings.hooksLabel, collapsed: false, items: hooks },


### PR DESCRIPTION
# Overview

Closes #480

The Reference index page was not in the sidebar, so VitePress computed its pager from the first sidebar entry: "Next page: Introduction" and no previous page. The Reference group now links to `/reference`, which puts the page between Contributing and the first component and makes the group title clickable. `verifyDocsI18n` asserts the link.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [ ] Did you write the JSDoc?