### PR TITLE
fix(useStorageState): reset to the default value when another tab clears the storage

### DIFF
--- a/.changeset/fix-storage-clear-sync.md
+++ b/.changeset/fix-storage-clear-sync.md
@@ -1,0 +1,5 @@
+---
+'react-simplikit': patch
+---
+
+Fix `useStorageState` retaining stale state when another tab clears localStorage.

--- a/packages/react-simplikit/src/hooks/useStorageState/useStorageState.spec.ts
+++ b/packages/react-simplikit/src/hooks/useStorageState/useStorageState.spec.ts
@@ -327,6 +327,61 @@ describe('useStorageState', () => {
       expect(result.current[0]).toBe('value from other tab');
     });
 
+    it.each(['default', undefined])('should reset to %s when another tab clears localStorage', async defaultValue => {
+      localStorage.setItem('test-key', JSON.stringify('stored value'));
+      const { result } = await renderHookSSR(() =>
+        useStorageState<string>('test-key', { storage: safeLocalStorage, defaultValue })
+      );
+      expect(result.current[0]).toBe('stored value');
+
+      await act(async () => {
+        localStorage.clear();
+        window.dispatchEvent(new StorageEvent('storage', { key: null, storageArea: localStorage }));
+      });
+
+      expect(result.current[0]).toBe(defaultValue);
+    });
+
+    it('should preserve localStorage state when sessionStorage is cleared', async () => {
+      localStorage.setItem('test-key', JSON.stringify('stored value'));
+      sessionStorage.setItem('test-key', JSON.stringify('session value'));
+      const { result } = await renderHookSSR(() => useStorageState<string>('test-key', { storage: safeLocalStorage }));
+
+      await act(async () => {
+        sessionStorage.clear();
+        window.dispatchEvent(new StorageEvent('storage', { key: null, storageArea: sessionStorage }));
+      });
+
+      expect(result.current[0]).toBe('stored value');
+    });
+
+    it('should reset to defaultValue when another tab removes the observed key', async () => {
+      localStorage.setItem('test-key', JSON.stringify('stored value'));
+      const { result } = await renderHookSSR(() =>
+        useStorageState<string>('test-key', { storage: safeLocalStorage, defaultValue: 'default' })
+      );
+
+      await act(async () => {
+        localStorage.removeItem('test-key');
+        window.dispatchEvent(new StorageEvent('storage', { key: 'test-key', storageArea: localStorage }));
+      });
+
+      expect(result.current[0]).toBe('default');
+    });
+
+    it('should preserve the observed value when another tab removes an unrelated key', async () => {
+      localStorage.setItem('test-key', JSON.stringify('stored value'));
+      localStorage.setItem('other-key', JSON.stringify('other value'));
+      const { result } = await renderHookSSR(() => useStorageState<string>('test-key', { storage: safeLocalStorage }));
+
+      await act(async () => {
+        localStorage.removeItem('other-key');
+        window.dispatchEvent(new StorageEvent('storage', { key: 'other-key', storageArea: localStorage }));
+      });
+
+      expect(result.current[0]).toBe('stored value');
+    });
+
     it('should return defaultValue when an error occurred while parsing data', async () => {
       const { result } = await renderHookSSR(() =>
         useStorageState<string>('test-key', { storage: safeLocalStorage, defaultValue: 'default' })

--- a/packages/react-simplikit/src/hooks/useStorageState/useStorageState.ts
+++ b/packages/react-simplikit/src/hooks/useStorageState/useStorageState.ts
@@ -156,7 +156,7 @@ export function useStorageState<T>(
       listeners.add(onStoreChange);
 
       const handler = (event: StorageEvent) => {
-        if (event.key === key) {
+        if (event.key == null || event.key === key) {
           onStoreChange();
         }
       };


### PR DESCRIPTION
# Overview

다른 탭에서 `localStorage.clear()`를 호출했을 때 `useStorageState`에 이전 값이 남는 문제를 수정합니다. 이제 새로고침이나 반환된 `refresh` 호출 없이 `defaultValue`로 돌아가며, 기본값이 없으면 `undefined`가 됩니다.

## 재현 방법

1. 같은 origin의 탭 A에서 `localStorage.setItem('name', JSON.stringify('Alice'))`로 값을 저장한 뒤 아래 hook을 마운트합니다.

   ```tsx
   const [name] = useStorageState<string>('name', { defaultValue: 'Guest' });
   ```

2. 탭 B에서 `localStorage.clear()`를 실행합니다.
3. 저장소는 비워지지만, 수정 전에는 탭 A의 `name`이 `'Alice'`로 남습니다. 기대값은 `'Guest'`입니다.

`clear()`로 전달되는 storage 이벤트의 `key`는 `null`입니다. 기존 구독 조건은 관찰 중인 key와 정확히 일치하는 이벤트만 처리하므로 전체 삭제를 놓칩니다. ([HTML 표준](https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-clear))

## 변경 내용

- `key`가 `null`인 이벤트에도 구독자를 깨워 기존 snapshot 로직으로 저장소를 다시 읽습니다.
- 이벤트의 `newValue`를 직접 적용하지 않으므로, 다른 종류의 저장소가 비워져도 hook이 사용하는 저장소의 값은 유지됩니다.
- 기본값 유무, 다른 저장소의 전체 삭제, 관찰 key 삭제, 무관한 key 삭제를 확인하는 테스트 5개와 patch changeset을 추가합니다.

## 검증

- 추가한 전체 삭제 테스트 2개가 수정 전 실패하고, 수정 후 `useStorageState` 테스트 53개가 모두 통과했습니다. 기존 SSR 검증도 포함됩니다.
- Chromium 152의 같은 origin 두 페이지에서 실제 `localStorage.clear()`를 실행했습니다. `isTrusted: true`, `key: null` 이벤트가 도착한 뒤 기본값이 있는 hook은 기본값으로, 없는 hook은 `undefined`로 갱신됐습니다.
- `yarn run test:coverage`: 통과. 라이브러리 테스트 579개 통과, `useStorageState.ts`와 `storage.ts`의 실행 구문 커버리지 100%.
- `yarn run test:compiled`: 581개 통과.
- `test:format`, `test:lint`, `test:type`, `test:docs`, `test:skill`, `test:codemod`, `verify:compiler`, `verify:pack`: 통과.

로컬 검증 환경: Node 24.19.0, Yarn 4.18.0, React 19.1.0.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] JSDoc 확인 — 기존 설명이 수정 후 동작과 일치합니다. 공개 API 변경이 없어 문서 변경은 필요하지 않습니다.
