### PR TITLE
fix(useControlledState): apply function updates in order when uncontrolled

### DIFF
--- a/.changeset/fix-controlled-state-function-updates.md
+++ b/.changeset/fix-controlled-state-function-updates.md
@@ -2,4 +2,8 @@
 'react-simplikit': patch
 ---
 
-`useControlledState` now applies multiple function updates in the same tick in order when uncontrolled, instead of computing each from the value captured at render. As a consequence, in uncontrolled mode `onChange` is called once after the state commits with the final value, not synchronously on every `setValue` call. Controlled mode is unchanged: it still computes from the current `value` prop, so two function updates in the same tick see the same previous value.
+`useControlledState` now applies multiple `setValue` calls in the same tick in order when uncontrolled, instead of computing each from the value captured at render. This affects both function updates and plain values: `setValue(prev => prev + 3)` twice now adds 6 instead of 3, and `setValue('b')` followed by `setValue('a')` from a current value of `'a'` now settles on `'a'` instead of `'b'`.
+
+As a consequence, in uncontrolled mode `onChange` is called once after the state commits with the final value, rather than synchronously on every `setValue` call. A parent that mirrors `onChange` into its own state therefore renders once more per update, no call is made when the final value equals the previous one, and a change reported by a component that unmounts in the same commit is dropped. Under StrictMode a single change is now reported once instead of twice.
+
+Controlled mode is unchanged: it still computes from the current `value` prop, so two function updates in the same tick see the same previous value.

--- a/.changeset/fix-controlled-state-function-updates.md
+++ b/.changeset/fix-controlled-state-function-updates.md
@@ -1,0 +1,5 @@
+---
+'react-simplikit': patch
+---
+
+`useControlledState` now applies multiple function updates in the same tick in order when uncontrolled, instead of computing each from the value captured at render. As a consequence, in uncontrolled mode `onChange` is called once after the state commits with the final value, not synchronously on every `setValue` call. Controlled mode is unchanged: it still computes from the current `value` prop, so two function updates in the same tick see the same previous value.

--- a/packages/react-simplikit/src/hooks/useControlledState/useControlledState.spec.tsx
+++ b/packages/react-simplikit/src/hooks/useControlledState/useControlledState.spec.tsx
@@ -139,7 +139,7 @@ describe('useControlledState', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('does not call onChange when equalityFn treats the next value as equal when uncontrolled', async () => {
+  it('does not call onChange for a value equalityFn treats as equal when uncontrolled', async () => {
     const onChange = vi.fn();
     const { result } = renderHookSSR(() =>
       useControlledState({
@@ -157,7 +157,7 @@ describe('useControlledState', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('reflects the value when the parent changes it externally when controlled', () => {
+  it('reflects a value the parent changes externally when controlled', () => {
     function App() {
       const [checked, setChecked] = useState(true);
       const [value] = useControlledState({ value: checked, onChange: setChecked });
@@ -200,7 +200,7 @@ describe('useControlledState', () => {
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
-  it('does not re-render when the parent rejects the change when controlled', () => {
+  it('does not re-render after the parent rejects a change when controlled', () => {
     let renderCount = 0;
     function App() {
       renderCount += 1;
@@ -221,5 +221,37 @@ describe('useControlledState', () => {
 
     expect(screen.getByTestId('value')).toHaveTextContent('10');
     expect(renderCount).toBe(1);
+  });
+
+  it('calls onChange once when setValue(undefined) switches from controlled back to uncontrolled', () => {
+    const onChange = vi.fn();
+    function App() {
+      const [prop, setProp] = useState<string | undefined>(undefined);
+      const [value, setValue] = useControlledState<string | undefined>({
+        value: prop,
+        defaultValue: 'a',
+        onChange: next => {
+          onChange(next);
+          setProp(next);
+        },
+      });
+
+      return (
+        <div>
+          <p data-testid="value">{String(value)}</p>
+          <button data-testid="control" onClick={() => setProp('b')} />
+          <button data-testid="clear" onClick={() => setValue(undefined)} />
+        </div>
+      );
+    }
+
+    render(<App />);
+    fireEvent.click(screen.getByTestId('control'));
+    expect(screen.getByTestId('value')).toHaveTextContent('b');
+
+    fireEvent.click(screen.getByTestId('clear'));
+    expect(screen.getByTestId('value')).toHaveTextContent('undefined');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(undefined);
   });
 });

--- a/packages/react-simplikit/src/hooks/useControlledState/useControlledState.spec.tsx
+++ b/packages/react-simplikit/src/hooks/useControlledState/useControlledState.spec.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
-import { act, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { useLayoutEffect, useState } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 import { renderHookSSR } from '../../_internal/test-utils/renderHookSSR.tsx';
 
@@ -114,5 +114,112 @@ describe('useControlledState', () => {
 
     const [nextValue] = result.current;
     expect(nextValue).toBe(8);
+  });
+
+  it('applies multiple function setState actions in order when uncontrolled', async () => {
+    const onChange = vi.fn();
+    const { result } = renderHookSSR(() => useControlledState({ defaultValue: 5, onChange }));
+
+    await act(async () => {
+      const [, setValue] = result.current;
+      setValue(prev => prev + 3);
+      setValue(prev => prev + 3);
+    });
+
+    const [nextValue] = result.current;
+    expect(nextValue).toBe(11);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(11);
+  });
+
+  it('does not call onChange on mount when uncontrolled', () => {
+    const onChange = vi.fn();
+    renderHookSSR(() => useControlledState({ defaultValue: 5, onChange }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not call onChange when equalityFn treats the next value as equal when uncontrolled', async () => {
+    const onChange = vi.fn();
+    const { result } = renderHookSSR(() =>
+      useControlledState({
+        defaultValue: { id: 1 },
+        onChange,
+        equalityFn: (prev, next) => prev.id === next.id,
+      })
+    );
+
+    await act(async () => {
+      const [, setValue] = result.current;
+      setValue({ id: 1 });
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('reflects the value when the parent changes it externally when controlled', () => {
+    function App() {
+      const [checked, setChecked] = useState(true);
+      const [value] = useControlledState({ value: checked, onChange: setChecked });
+
+      return (
+        <div>
+          <p data-testid="value">{String(value)}</p>
+          <button onClick={() => setChecked(false)}>Clear value</button>
+        </div>
+      );
+    }
+
+    render(<App />);
+    expect(screen.getByTestId('value')).toHaveTextContent('true');
+
+    fireEvent.click(screen.getByText('Clear value'));
+    expect(screen.getByTestId('value')).toHaveTextContent('false');
+  });
+
+  it('toggles with a function setState action through the parent when controlled', () => {
+    const onChange = vi.fn();
+    function App() {
+      const [checked, setChecked] = useState(false);
+      const [value, setValue] = useControlledState({
+        value: checked,
+        onChange: next => {
+          onChange(next);
+          setChecked(next);
+        },
+      });
+
+      return <button role="checkbox" aria-checked={value} onClick={() => setValue(prev => !prev)} />;
+    }
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'true');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('does not re-render when the parent rejects the change when controlled', () => {
+    let renderCount = 0;
+    function App() {
+      renderCount += 1;
+      const [value, setValue] = useState(10);
+      const [state, setState] = useControlledState({
+        value,
+        onChange: next => setValue(Math.min(next, 10)),
+      });
+
+      useLayoutEffect(function pushEveryRender() {
+        setState(12);
+      });
+
+      return <p data-testid="value">{state}</p>;
+    }
+
+    render(<App />);
+
+    expect(screen.getByTestId('value')).toHaveTextContent('10');
+    expect(renderCount).toBe(1);
   });
 });

--- a/packages/react-simplikit/src/hooks/useControlledState/useControlledState.spec.tsx
+++ b/packages/react-simplikit/src/hooks/useControlledState/useControlledState.spec.tsx
@@ -149,12 +149,15 @@ describe('useControlledState', () => {
       })
     );
 
+    const [initialValue] = result.current;
+
     await act(async () => {
       const [, setValue] = result.current;
       setValue({ id: 1 });
     });
 
     expect(onChange).not.toHaveBeenCalled();
+    expect(result.current[0]).toBe(initialValue);
   });
 
   it('reflects a value the parent changes externally when controlled', () => {
@@ -253,5 +256,100 @@ describe('useControlledState', () => {
     expect(screen.getByTestId('value')).toHaveTextContent('undefined');
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('does not call onChange on mount when equalityFn is not reflexive when uncontrolled', () => {
+    const onChange = vi.fn();
+    renderHookSSR(() => useControlledState({ defaultValue: 5, onChange, equalityFn: () => false }));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('notifies through the latest onChange after the parent swaps it when uncontrolled', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { result, rerender } = renderHookSSR(
+      ({ onChange }: { onChange: (next: number) => void }) => useControlledState({ defaultValue: 5, onChange }),
+      { initialProps: { onChange: first } }
+    );
+
+    rerender({ onChange: second });
+    await act(async () => {
+      const [, setValue] = result.current;
+      setValue(6);
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith(6);
+  });
+
+  it('notifies a change back to the initial value when uncontrolled', async () => {
+    const onChange = vi.fn();
+    const { result } = renderHookSSR(() => useControlledState({ defaultValue: 5, onChange }));
+
+    await act(async () => {
+      const [, setValue] = result.current;
+      setValue(6);
+    });
+    await act(async () => {
+      const [, setValue] = result.current;
+      setValue(5);
+    });
+
+    expect(onChange.mock.calls).toEqual([[6], [5]]);
+  });
+
+  it('notifies a change made in the same event the parent takes control', () => {
+    const onChange = vi.fn();
+    function App() {
+      const [prop, setProp] = useState<string | undefined>(undefined);
+      const [value, setValue] = useControlledState<string | undefined>({ value: prop, defaultValue: 'a', onChange });
+
+      return (
+        <div>
+          <p data-testid="value">{String(value)}</p>
+          <button
+            data-testid="take"
+            onClick={() => {
+              setValue('b');
+              setProp('b');
+            }}
+          />
+          <button data-testid="release" onClick={() => setProp(undefined)} />
+        </div>
+      );
+    }
+
+    render(<App />);
+    fireEvent.click(screen.getByTestId('take'));
+    expect(screen.getByTestId('value')).toHaveTextContent('b');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('b');
+
+    fireEvent.click(screen.getByTestId('release'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('computes a function update from the value prop, not the internal state, when controlled', () => {
+    const onChange = vi.fn();
+    function App() {
+      const [count, setCount] = useState(5);
+      const [value, setValue] = useControlledState({
+        value: count,
+        defaultValue: 0,
+        onChange: next => {
+          onChange(next);
+          setCount(next);
+        },
+      });
+
+      return <button onClick={() => setValue(prev => prev + 3)}>{value}</button>;
+    }
+
+    render(<App />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toHaveTextContent('8');
+    expect(onChange).toHaveBeenCalledWith(8);
   });
 });

--- a/packages/react-simplikit/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/react-simplikit/src/hooks/useControlledState/useControlledState.ts
@@ -84,7 +84,11 @@ export function useControlledState<T>({
       const nextValue = isSetStateAction(next) ? next(value) : next;
 
       if (equalityFn(value, nextValue) === true) return;
-      if (nextValue === undefined) setUncontrolledState(nextValue);
+      if (nextValue === undefined) {
+        // Keep the notify effect from reporting this again once the parent hands control back.
+        prevUncontrolledRef.current = nextValue;
+        setUncontrolledState(nextValue);
+      }
       onChange?.(nextValue);
     },
     [controlled, onChange, equalityFn, value]

--- a/packages/react-simplikit/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/react-simplikit/src/hooks/useControlledState/useControlledState.ts
@@ -1,4 +1,6 @@
-import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
+
+import { usePreservedCallback } from '../usePreservedCallback/index.ts';
 
 type ControlledState<T> = { value: T; defaultValue?: never } | { defaultValue: T; value?: T };
 
@@ -51,14 +53,38 @@ export function useControlledState<T>({
   const [uncontrolledState, setUncontrolledState] = useState(defaultValue as T);
   const controlled = valueProp !== undefined;
   const value = controlled ? valueProp : uncontrolledState;
+  const preservedOnChange = usePreservedCallback((next: T) => onChange?.(next));
+
+  // Uncontrolled updates go through React's queue so function updates apply in order.
+  // onChange fires here, after commit, because the updater must stay pure (StrictMode runs it twice).
+  const prevUncontrolledRef = useRef(uncontrolledState);
+  useEffect(
+    function notifyUncontrolledChange() {
+      if (controlled === true) return;
+      if (equalityFn(prevUncontrolledRef.current, uncontrolledState) === true) return;
+      prevUncontrolledRef.current = uncontrolledState;
+      preservedOnChange(uncontrolledState);
+    },
+    [controlled, uncontrolledState, equalityFn, preservedOnChange]
+  );
 
   const setValue = useCallback(
     (next: SetStateAction<T>) => {
+      if (controlled === false) {
+        setUncontrolledState(prev => {
+          const nextValue = isSetStateAction(next) ? next(prev) : next;
+          return equalityFn(prev, nextValue) === true ? prev : nextValue;
+        });
+        return;
+      }
+
+      // Computed from the committed `value` on purpose: two function updates in the same tick
+      // see the same `prev`. Tracking the pending value in a ref needs a forced re-render to
+      // reset it, which loops when the parent rejects a change the caller re-issues every render.
       const nextValue = isSetStateAction(next) ? next(value) : next;
 
       if (equalityFn(value, nextValue) === true) return;
-      if (controlled === false) setUncontrolledState(nextValue);
-      if (controlled === true && nextValue === undefined) setUncontrolledState(nextValue);
+      if (nextValue === undefined) setUncontrolledState(nextValue);
       onChange?.(nextValue);
     },
     [controlled, onChange, equalityFn, value]

--- a/packages/react-simplikit/src/hooks/useControlledState/useControlledState.ts
+++ b/packages/react-simplikit/src/hooks/useControlledState/useControlledState.ts
@@ -60,12 +60,12 @@ export function useControlledState<T>({
   const prevUncontrolledRef = useRef(uncontrolledState);
   useEffect(
     function notifyUncontrolledChange() {
-      if (controlled === true) return;
-      if (equalityFn(prevUncontrolledRef.current, uncontrolledState) === true) return;
+      // The updater below already folds equal values into `prev`, so a reference check is enough here.
+      if (prevUncontrolledRef.current === uncontrolledState) return;
       prevUncontrolledRef.current = uncontrolledState;
       preservedOnChange(uncontrolledState);
     },
-    [controlled, uncontrolledState, equalityFn, preservedOnChange]
+    [uncontrolledState, preservedOnChange]
   );
 
   const setValue = useCallback(


### PR DESCRIPTION
# Overview

Supersedes #344. Co-authored with @kyukyu-dev, whose test case this builds on.

## Problem

`useControlledState` computed function updates from the `value` captured at render, so two updates in the same tick both saw the same `prev`:

```ts
const [count, setCount] = useControlledState({ defaultValue: 5 });

setCount(prev => prev + 3);
setCount(prev => prev + 3);
// useState: 11, useControlledState: 8
```

This affected both modes.

## What changed

**Uncontrolled mode** now hands the updater to React's own `useState` queue, so multiple `setValue` calls in the same tick apply in order. This covers plain values too: `setValue('b')` followed by `setValue('a')` from `'a'` now settles on `'a'` instead of `'b'`.

`onChange` is called once after commit with the final value. It used to be called synchronously on every `setValue` call, so:

- a parent that mirrors `onChange` into its own state renders once more per update
- no call is made when the final value equals the previous one
- a change made in the same commit the component unmounts is not reported
- under StrictMode a single change is reported once, not twice

In exchange the updater stays pure, which matters under StrictMode and the React Compiler.

**Controlled mode is unchanged.** It still computes from the committed `value`, so two function updates in the same tick see the same `prev`.

## Why not fix controlled mode too

#344 fixed both modes by tracking the pending value in a ref and forcing a re-render to reset it. While reviewing it we found that the forced re-render fires even when the parent rejects the change, so any caller that re-issues `setValue` on every render never settles:

```tsx
function App() {
  const [value, setValue] = useState(10);
  const [state, setState] = useControlledState({
    value,
    onChange: next => setValue(Math.min(next, 10)), // parent clamps, effectively rejects 12
  });

  useLayoutEffect(function push() {
    setState(12); // no deps: runs on every render
  });

  return <p>{state}</p>;
}
// main: settles at 10
// #344: "Maximum update depth exceeded"
```

A fresh object in an effect's deps triggers the same loop, and a `useEffect` variant does not hit React's guard at all. The controlled-mode double update is rare in practice, while the loop hits ordinary code, so we took the same trade-off Radix makes in `useControllableState`: fix uncontrolled mode with React's queue, accept the limitation in controlled mode. React Aria's `useControlledState` takes the opposite trade-off and has the loop.

A test pins the choice: a parent that rejects a change while the caller re-issues it on every render must not re-render.

## Follow-up commits

- `setValue(undefined)` in controlled mode also writes the internal state so the value stays `undefined` once the parent hands control back. The notify effect then reported that change a second time; the ref it compares against is now synced at the write site.
- The notify effect compared with `equalityFn`, so a non-reflexive comparator reported a change on mount and an inline one re-ran the effect every render. The updater already folds equal values into `prev`, so the effect now uses a reference check. Its `controlled` early return only delayed the notification when the parent took control in the same event as the change, so it is gone.

## Tests

Uncontrolled:

- two function updates in the same tick apply in order and `onChange` fires once with the final value
- `onChange` is not called on mount, also with a non-reflexive `equalityFn`
- a value `equalityFn` treats as equal neither calls `onChange` nor replaces the state reference
- the latest `onChange` is used after the parent swaps it
- a change back to the initial value is reported
- a change made in the same event the parent takes control is reported, with no late call when control is released

Controlled:

- the parent changing `value` externally is reflected, and a function update toggles through the parent (both ported from Radix's `useControllableState` tests)
- a function update computes from the `value` prop, not the internal state
- a rejected change re-issued on every render does not re-render
- `setValue(undefined)` handing control back reports to `onChange` once, not twice

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
