### PR TITLE
fix: land the mergeRefs, buildContext and mergeProps fixes from #277, #279 and #281

### DIFF
--- a/.changeset/build-context-provider-display-name.md
+++ b/.changeset/build-context-provider-display-name.md
@@ -1,0 +1,5 @@
+---
+'react-simplikit': patch
+---
+
+`buildContext` now sets `displayName` on the returned `Provider` to `` `${contextName}Provider` ``, so React DevTools shows which context a provider belongs to instead of a bare `Provider`. The documentation example also passed `null` as the default values, which the signature rejects; it now passes an object.

--- a/.changeset/merge-refs-forward-cleanup.md
+++ b/.changeset/merge-refs-forward-cleanup.md
@@ -1,0 +1,5 @@
+---
+'react-simplikit': patch
+---
+
+`mergeRefs` now forwards the cleanup functions that callback refs can return since React 19. When at least one of the merged refs returns a cleanup, the merged ref returns one as well, so React runs those cleanups on detach instead of calling the callbacks with `null`; refs that returned nothing are still reset to `null` inside that cleanup. When no ref returns a cleanup the merged ref returns nothing, as before, so React 18 keeps its existing `null` call and does not warn.

--- a/packages/plugin/skills/react-simplikit/references/buildContext.md
+++ b/packages/plugin/skills/react-simplikit/references/buildContext.md
@@ -54,10 +54,9 @@ function buildContext(
 ## Example
 
 ```tsx
-const [Provider, useContext] = buildContext<{ title: string }>(
-  'TestContext',
-  null
-);
+const [Provider, useContext] = buildContext<{ title: string }>('TestContext', {
+  title: 'Default title',
+});
 
 function Inner() {
   const { title } = useContext();

--- a/packages/plugin/skills/react-simplikit/references/mergeRefs.md
+++ b/packages/plugin/skills/react-simplikit/references/mergeRefs.md
@@ -1,6 +1,6 @@
 # mergeRefs
 
-This function takes multiple refs (RefObject or RefCallback) and returns a single ref that updates all provided refs. It's useful when you need to pass multiple refs to a single element.
+This function takes multiple refs (RefObject or RefCallback) and returns a single ref that updates all provided refs. It's useful when you need to pass multiple refs to a single element. When a callback ref returns a cleanup function (React 19), the merged ref returns one as well and runs every cleanup on detach.
 
 ## Interface
 

--- a/packages/react-simplikit/src/utils/buildContext/buildContext.md
+++ b/packages/react-simplikit/src/utils/buildContext/buildContext.md
@@ -54,10 +54,9 @@ function buildContext(
 ## Example
 
 ```tsx
-const [Provider, useContext] = buildContext<{ title: string }>(
-  'TestContext',
-  null
-);
+const [Provider, useContext] = buildContext<{ title: string }>('TestContext', {
+  title: 'Default title',
+});
 
 function Inner() {
   const { title } = useContext();

--- a/packages/react-simplikit/src/utils/buildContext/buildContext.spec.tsx
+++ b/packages/react-simplikit/src/utils/buildContext/buildContext.spec.tsx
@@ -123,4 +123,9 @@ describe('buildContext', () => {
         ))
     ).rejects.toThrow();
   });
+  it('should name the provider after the context for devtools', () => {
+    const [Provider] = buildContext<TestContextType>('Test');
+
+    expect(Provider.displayName).toBe('TestProvider');
+  });
 });

--- a/packages/react-simplikit/src/utils/buildContext/buildContext.tsx
+++ b/packages/react-simplikit/src/utils/buildContext/buildContext.tsx
@@ -14,7 +14,7 @@ type ProviderProps<ContextValuesType> = (ContextValuesType & { children: ReactNo
  * - useContext `() => ContextValuesType` - The hook that uses the context;
  *
  * @example
- * const [Provider, useContext] = buildContext<{ title: string }>('TestContext', null);
+ * const [Provider, useContext] = buildContext<{ title: string }>('TestContext', { title: 'Default title' });
  *
  * function Inner() {
  *   const { title } = useContext();
@@ -43,13 +43,15 @@ export function buildContext<ContextValuesType extends object>(
     'use no memo';
 
     const value = useMemo(
-      () => (Object.keys(contextValues).length > 0 ? contextValues : null),
+      () => (Object.keys(contextValues).length > 0 ? (contextValues as ContextValuesType) : undefined),
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [...Object.values(contextValues)]
-    ) as ContextValuesType;
+    );
 
     return <Context.Provider value={value}>{children}</Context.Provider>;
   }
+
+  Provider.displayName = `${contextName}Provider`;
 
   function useInnerContext() {
     const context = useContext(Context);

--- a/packages/react-simplikit/src/utils/buildContext/ko/buildContext.md
+++ b/packages/react-simplikit/src/utils/buildContext/ko/buildContext.md
@@ -52,10 +52,9 @@ function buildContext(
 ## 예시
 
 ```tsx
-const [Provider, useContext] = buildContext<{ title: string }>(
-  'TestContext',
-  null
-);
+const [Provider, useContext] = buildContext<{ title: string }>('TestContext', {
+  title: 'Default title',
+});
 
 function Inner() {
   const { title } = useContext();

--- a/packages/react-simplikit/src/utils/mergeProps/mergeProps.ts
+++ b/packages/react-simplikit/src/utils/mergeProps/mergeProps.ts
@@ -43,13 +43,7 @@ function pushProp(prev: BaseProps, curr: BaseProps): BaseProps {
         break;
       }
       default: {
-        const mergedFunction = mergeFunction(prev[key], curr[key]);
-
-        if (mergedFunction) {
-          prev[key] = mergedFunction;
-        } else if (curr[key] !== undefined) {
-          prev[key] = curr[key];
-        }
+        prev[key] = mergeFunction(prev[key], curr[key]) ?? curr[key];
       }
     }
   }

--- a/packages/react-simplikit/src/utils/mergeRefs/ko/mergeRefs.md
+++ b/packages/react-simplikit/src/utils/mergeRefs/ko/mergeRefs.md
@@ -1,6 +1,6 @@
 # mergeRefs
 
-이 함수는 여러 개의 refs(RefObject 또는 RefCallback)를 받아서 제공된 모든 refs를 업데이트하는 단일 ref를 반환해요. 단일 요소에 여러 refs를 전달해야 할 때 유용해요.
+이 함수는 여러 개의 refs(RefObject 또는 RefCallback)를 받아서 제공된 모든 refs를 업데이트하는 단일 ref를 반환해요. 단일 요소에 여러 refs를 전달해야 할 때 유용해요. 콜백 ref가 정리 함수를 반환하면(React 19) 합쳐진 ref도 정리 함수를 반환하고, 분리될 때 모든 정리 함수를 실행해요.
 
 ## 인터페이스
 

--- a/packages/react-simplikit/src/utils/mergeRefs/mergeRefs.md
+++ b/packages/react-simplikit/src/utils/mergeRefs/mergeRefs.md
@@ -1,6 +1,6 @@
 # mergeRefs
 
-This function takes multiple refs (RefObject or RefCallback) and returns a single ref that updates all provided refs. It's useful when you need to pass multiple refs to a single element.
+This function takes multiple refs (RefObject or RefCallback) and returns a single ref that updates all provided refs. It's useful when you need to pass multiple refs to a single element. When a callback ref returns a cleanup function (React 19), the merged ref returns one as well and runs every cleanup on detach.
 
 ## Interface
 

--- a/packages/react-simplikit/src/utils/mergeRefs/mergeRefs.spec.ts
+++ b/packages/react-simplikit/src/utils/mergeRefs/mergeRefs.spec.ts
@@ -1,6 +1,6 @@
-import { useCallback, useRef } from 'react';
-import { act } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { createElement, useCallback, useRef } from 'react';
+import { act, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 import { renderHookSSR } from '../../_internal/test-utils/renderHookSSR.tsx';
 
@@ -74,5 +74,50 @@ describe('mergeRefs', () => {
 
     expect(result.current.ref1.current).toBe(value);
     expect(ref3Value).toBe(value);
+  });
+  it('should call the cleanup returned by a callback ref when the element unmounts', () => {
+    const cleanup = vi.fn();
+    const callbackRef = vi.fn(() => cleanup);
+
+    const { unmount } = render(createElement('div', { ref: mergeRefs<HTMLDivElement>(callbackRef) }));
+
+    expect(callbackRef).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(callbackRef).toHaveBeenCalledTimes(1);
+    expect(callbackRef).not.toHaveBeenCalledWith(null);
+  });
+
+  it('should reset refs without a cleanup when another ref returned one', () => {
+    const cleanup = vi.fn();
+    const callbackRefWithCleanup = vi.fn(() => cleanup);
+    const callbackRef = vi.fn(() => undefined);
+    const objectRef = { current: null as HTMLDivElement | null };
+
+    const { unmount } = render(
+      createElement('div', {
+        ref: mergeRefs<HTMLDivElement | null>(callbackRefWithCleanup, objectRef, null, callbackRef),
+      })
+    );
+
+    expect(objectRef.current).toBeInstanceOf(HTMLDivElement);
+
+    unmount();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(objectRef.current).toBeNull();
+    expect(callbackRef).toHaveBeenLastCalledWith(null);
+  });
+
+  it('should return nothing when no ref returns a cleanup', () => {
+    const callbackRef = () => undefined;
+    const objectRef = { current: null as string | null };
+
+    const mergedRef = mergeRefs<string | null>(callbackRef, objectRef);
+
+    expect(mergedRef('test-value')).toBeUndefined();
   });
 });

--- a/packages/react-simplikit/src/utils/mergeRefs/mergeRefs.ts
+++ b/packages/react-simplikit/src/utils/mergeRefs/mergeRefs.ts
@@ -4,6 +4,7 @@ import { RefCallback, RefObject } from 'react';
  * @description
  * This function takes multiple refs (RefObject or RefCallback) and returns a single ref that updates all provided refs.
  * It's useful when you need to pass multiple refs to a single element.
+ * When a callback ref returns a cleanup function (React 19), the merged ref returns one as well and runs every cleanup on detach.
  *
  * @template T - The type of target to be referenced.
  *
@@ -36,17 +37,51 @@ import { RefCallback, RefObject } from 'react';
  */
 export function mergeRefs<T>(...refs: Array<RefObject<T> | RefCallback<T> | null | undefined>): RefCallback<T> {
   return value => {
-    for (const ref of refs) {
+    let hasCleanup = false;
+
+    const cleanups = refs.map(ref => {
       if (ref == null) {
-        continue;
+        return undefined;
       }
 
-      if (typeof ref === 'function') {
-        ref(value);
-        continue;
+      const cleanup = setRef(ref, value);
+
+      if (typeof cleanup === 'function') {
+        hasCleanup = true;
       }
 
-      (ref as RefObject<T | null>).current = value;
+      return cleanup;
+    });
+
+    // Returning a function only when a ref asked for one keeps the React 18 path
+    // (React calls this ref again with `null`) untouched and avoids its dev warning.
+    if (!hasCleanup) {
+      return;
     }
+
+    return () => {
+      refs.forEach((ref, index) => {
+        if (ref == null) {
+          return;
+        }
+
+        const cleanup = cleanups[index];
+
+        if (typeof cleanup === 'function') {
+          cleanup();
+          return;
+        }
+
+        setRef(ref, null);
+      });
+    };
   };
+}
+
+function setRef<T>(ref: RefObject<T> | RefCallback<T>, value: T | null) {
+  if (typeof ref === 'function') {
+    return ref(value);
+  }
+
+  (ref as RefObject<T | null>).current = value;
 }


### PR DESCRIPTION
# Overview

Lands the three community PRs from @wo-o29 (#277, #279, #281) on the current package layout, one commit each with the original author as co-author. The problems they report are real; two of them are applied in a slightly different shape, noted below.

## `mergeRefs` — forward React 19 ref cleanups (#281)

React 19 lets a callback ref return a cleanup function. `mergeRefs` called the inner refs and discarded their return values, so React never saw a cleanup, called the merged ref with `null` instead, and the inner cleanup never ran.

The merged ref now collects what each inner ref returns. If at least one returned a cleanup, the merged ref returns a cleanup that runs those and resets the remaining refs to `null`. If none did, it returns nothing, exactly as before, so React 18 keeps its `null` call and does not log its "callback ref should not return a function" warning. This is the approach Radix's `composeRefs` uses; #281 always returned a cleanup, which would trigger that warning on React 18.

Tests render a real element and assert the cleanup runs on unmount, that mixed refs (cleanup, object ref, `null`, plain callback) are all handled, and that nothing is returned when no ref asks for a cleanup.

## `buildContext` — `displayName`, docs example, type mismatch (#277)

- `Provider.displayName` is now `` `${contextName}Provider` `` so DevTools shows which context a provider belongs to.
- The JSDoc/docs example passed `null` as the default values, which the signature rejects. It now passes an object.
- The context is typed `ContextValuesType | undefined` but the provider supplied `null` behind an `as` cast. The provider now supplies `undefined`, which removes the cast. #277 unified on `null` instead; `undefined` keeps the existing type and the `!= null` guards, so a JS caller still passing `null` from the old docs keeps getting the "must be used within" error.

## `mergeProps` — remove the dead branch (#279)

`pushProp` already skips `undefined` values at the top of the loop, so the inner `else if (curr[key] !== undefined)` was always true. Folded into `mergeFunction(...) ?? curr[key]`. The `mergeStyle` simplification from #279 is not included: dropping `if (a == null) return b` changes the identity of the returned style object.

## Checklist

- [x] Did you write the test code?
- [x] Have you run `yarn run fix` to format and lint the code and docs?
- [x] Have you run `yarn run test:coverage` to make sure there is no uncovered line?
- [x] Did you write the JSDoc?
