### PR TITLE
fix(docs): add fallback text for functions without parameters

### DIFF
--- a/.scripts/commands/generateDocs/index.ts
+++ b/.scripts/commands/generateDocs/index.ts
@@ -199,8 +199,12 @@ ${description}
 ${await prettier.format(`function ${name}${getTemplateCode()}(${getParamsCode()}): ${returns == null ? 'void' : returns.type};`, { ...prettierConfig, parser: 'typescript' })}\`\`\`
 
 ### Parameters
-
-${await prettier.format(paramsProps.map(props => getParamUl(...props)).join(''), { ...prettierConfig, parser: 'vue' })}
+${
+  params.length === 0
+    ? '\nThis function does not accept any parameters.'
+    : `
+${await prettier.format(paramsProps.map(props => getParamUl(...props)).join(''), { ...prettierConfig, parser: 'vue' })}`
+}
 ### Return Value
 ${
   returns == null

--- a/packages/plugin/skills/react-simplikit/references/disableBodyScrollLock.md
+++ b/packages/plugin/skills/react-simplikit/references/disableBodyScrollLock.md
@@ -12,6 +12,8 @@ function disableBodyScrollLock(): void;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface name="" type="void" description="" />

--- a/packages/plugin/skills/react-simplikit/references/enableBodyScrollLock.md
+++ b/packages/plugin/skills/react-simplikit/references/enableBodyScrollLock.md
@@ -12,6 +12,8 @@ function enableBodyScrollLock(): void;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface name="" type="void" description="" />

--- a/packages/plugin/skills/react-simplikit/references/getKeyboardHeight.md
+++ b/packages/plugin/skills/react-simplikit/references/getKeyboardHeight.md
@@ -16,6 +16,8 @@ function getKeyboardHeight(): number;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/plugin/skills/react-simplikit/references/getSafeAreaInset.md
+++ b/packages/plugin/skills/react-simplikit/references/getSafeAreaInset.md
@@ -24,6 +24,8 @@ function getSafeAreaInset(): SafeAreaInset;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/plugin/skills/react-simplikit/references/isKeyboardVisible.md
+++ b/packages/plugin/skills/react-simplikit/references/isKeyboardVisible.md
@@ -12,6 +12,8 @@ function isKeyboardVisible(): boolean;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/plugin/skills/react-simplikit/references/isServer.md
+++ b/packages/plugin/skills/react-simplikit/references/isServer.md
@@ -10,6 +10,8 @@ function isServer(): boolean;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/plugin/skills/react-simplikit/references/useBodyScrollLock.md
+++ b/packages/plugin/skills/react-simplikit/references/useBodyScrollLock.md
@@ -12,6 +12,8 @@ function useBodyScrollLock(): void;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 This hook does not return anything.

--- a/packages/plugin/skills/react-simplikit/references/useIsClient.md
+++ b/packages/plugin/skills/react-simplikit/references/useIsClient.md
@@ -10,6 +10,8 @@ function useIsClient(): boolean;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/plugin/skills/react-simplikit/references/useLoading.md
+++ b/packages/plugin/skills/react-simplikit/references/useLoading.md
@@ -13,6 +13,8 @@ function useLoading(): [
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/plugin/skills/react-simplikit/references/useNetworkStatus.md
+++ b/packages/plugin/skills/react-simplikit/references/useNetworkStatus.md
@@ -17,6 +17,8 @@ function useNetworkStatus(): NetworkStatus;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/plugin/skills/react-simplikit/references/usePageVisibility.md
+++ b/packages/plugin/skills/react-simplikit/references/usePageVisibility.md
@@ -12,6 +12,8 @@ function usePageVisibility(): PageVisibility;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/plugin/skills/react-simplikit/references/useSafeAreaInset.md
+++ b/packages/plugin/skills/react-simplikit/references/useSafeAreaInset.md
@@ -16,6 +16,8 @@ function useSafeAreaInset(): SafeAreaInset;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/plugin/skills/react-simplikit/references/useVisualViewport.md
+++ b/packages/plugin/skills/react-simplikit/references/useVisualViewport.md
@@ -14,6 +14,8 @@ function useVisualViewport(): { viewport: VisualViewportState | null };
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/hooks/useBodyScrollLock/ko/useBodyScrollLock.md
+++ b/packages/react-simplikit/src/hooks/useBodyScrollLock/ko/useBodyScrollLock.md
@@ -10,7 +10,7 @@ function useBodyScrollLock(): void;
 
 ### 매개변수
 
-이 훅은 매개변수를 받지 않아요.
+이 함수는 매개변수를 받지 않아요.
 
 ### 반환값
 

--- a/packages/react-simplikit/src/hooks/useBodyScrollLock/useBodyScrollLock.md
+++ b/packages/react-simplikit/src/hooks/useBodyScrollLock/useBodyScrollLock.md
@@ -12,6 +12,8 @@ function useBodyScrollLock(): void;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 This hook does not return anything.

--- a/packages/react-simplikit/src/hooks/useIsClient/ko/useIsClient.md
+++ b/packages/react-simplikit/src/hooks/useIsClient/ko/useIsClient.md
@@ -8,6 +8,10 @@
 function useIsClient(): boolean;
 ```
 
+### 파라미터
+
+이 함수는 파라미터를 받지 않아요.
+
 ### 반환 값
 
 <Interface

--- a/packages/react-simplikit/src/hooks/useIsClient/useIsClient.md
+++ b/packages/react-simplikit/src/hooks/useIsClient/useIsClient.md
@@ -10,6 +10,8 @@ function useIsClient(): boolean;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/hooks/useLoading/ko/useLoading.md
+++ b/packages/react-simplikit/src/hooks/useLoading/ko/useLoading.md
@@ -13,6 +13,8 @@ function useLoading(): [
 
 ### 파라미터
 
+이 함수는 파라미터를 받지 않아요.
+
 ### 반환 값
 
 <Interface

--- a/packages/react-simplikit/src/hooks/useLoading/useLoading.md
+++ b/packages/react-simplikit/src/hooks/useLoading/useLoading.md
@@ -13,6 +13,8 @@ function useLoading(): [
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/hooks/useNetworkStatus/ko/useNetworkStatus.md
+++ b/packages/react-simplikit/src/hooks/useNetworkStatus/ko/useNetworkStatus.md
@@ -10,7 +10,7 @@ function useNetworkStatus(): NetworkStatus;
 
 ### 파라미터
 
-이 훅은 파라미터를 받지 않아요.
+이 함수는 파라미터를 받지 않아요.
 
 ### 반환값
 

--- a/packages/react-simplikit/src/hooks/useNetworkStatus/useNetworkStatus.md
+++ b/packages/react-simplikit/src/hooks/useNetworkStatus/useNetworkStatus.md
@@ -17,6 +17,8 @@ function useNetworkStatus(): NetworkStatus;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/hooks/usePageVisibility/ko/usePageVisibility.md
+++ b/packages/react-simplikit/src/hooks/usePageVisibility/ko/usePageVisibility.md
@@ -12,7 +12,7 @@ function usePageVisibility(): PageVisibility;
 
 ### 매개변수
 
-이 훅은 매개변수를 받지 않아요.
+이 함수는 매개변수를 받지 않아요.
 
 ### 반환값
 

--- a/packages/react-simplikit/src/hooks/usePageVisibility/usePageVisibility.md
+++ b/packages/react-simplikit/src/hooks/usePageVisibility/usePageVisibility.md
@@ -12,6 +12,8 @@ function usePageVisibility(): PageVisibility;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/hooks/useSafeAreaInset/ko/useSafeAreaInset.md
+++ b/packages/react-simplikit/src/hooks/useSafeAreaInset/ko/useSafeAreaInset.md
@@ -16,7 +16,7 @@ function useSafeAreaInset(): SafeAreaInset;
 
 ### 파라미터
 
-이 훅은 파라미터를 받지 않아요.
+이 함수는 파라미터를 받지 않아요.
 
 ### 반환 값
 

--- a/packages/react-simplikit/src/hooks/useSafeAreaInset/useSafeAreaInset.md
+++ b/packages/react-simplikit/src/hooks/useSafeAreaInset/useSafeAreaInset.md
@@ -16,6 +16,8 @@ function useSafeAreaInset(): SafeAreaInset;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/hooks/useVisualViewport/ko/useVisualViewport.md
+++ b/packages/react-simplikit/src/hooks/useVisualViewport/ko/useVisualViewport.md
@@ -12,7 +12,7 @@ function useVisualViewport(): { viewport: VisualViewportState | null };
 
 ### 매개변수
 
-이 훅은 매개변수를 받지 않아요.
+이 함수는 매개변수를 받지 않아요.
 
 ### 반환값
 

--- a/packages/react-simplikit/src/hooks/useVisualViewport/useVisualViewport.md
+++ b/packages/react-simplikit/src/hooks/useVisualViewport/useVisualViewport.md
@@ -14,6 +14,8 @@ function useVisualViewport(): { viewport: VisualViewportState | null };
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/utils/disableBodyScrollLock/disableBodyScrollLock.md
+++ b/packages/react-simplikit/src/utils/disableBodyScrollLock/disableBodyScrollLock.md
@@ -12,6 +12,8 @@ function disableBodyScrollLock(): void;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface name="" type="void" description="" />

--- a/packages/react-simplikit/src/utils/disableBodyScrollLock/ko/disableBodyScrollLock.md
+++ b/packages/react-simplikit/src/utils/disableBodyScrollLock/ko/disableBodyScrollLock.md
@@ -10,6 +10,8 @@ function disableBodyScrollLock(): void;
 
 ### 파라미터
 
+이 함수는 파라미터를 받지 않아요.
+
 ### 반환 값
 
 <Interface name="" type="void" description="" />

--- a/packages/react-simplikit/src/utils/enableBodyScrollLock/enableBodyScrollLock.md
+++ b/packages/react-simplikit/src/utils/enableBodyScrollLock/enableBodyScrollLock.md
@@ -12,6 +12,8 @@ function enableBodyScrollLock(): void;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface name="" type="void" description="" />

--- a/packages/react-simplikit/src/utils/enableBodyScrollLock/ko/enableBodyScrollLock.md
+++ b/packages/react-simplikit/src/utils/enableBodyScrollLock/ko/enableBodyScrollLock.md
@@ -10,6 +10,8 @@ function enableBodyScrollLock(): void;
 
 ### 파라미터
 
+이 함수는 파라미터를 받지 않아요.
+
 ### 반환 값
 
 <Interface name="" type="void" description="" />

--- a/packages/react-simplikit/src/utils/getKeyboardHeight/getKeyboardHeight.md
+++ b/packages/react-simplikit/src/utils/getKeyboardHeight/getKeyboardHeight.md
@@ -16,6 +16,8 @@ function getKeyboardHeight(): number;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/utils/getKeyboardHeight/ko/getKeyboardHeight.md
+++ b/packages/react-simplikit/src/utils/getKeyboardHeight/ko/getKeyboardHeight.md
@@ -10,6 +10,8 @@ function getKeyboardHeight(): number;
 
 ### 파라미터
 
+이 함수는 파라미터를 받지 않아요.
+
 ### 반환 값
 
 <Interface

--- a/packages/react-simplikit/src/utils/getSafeAreaInset/getSafeAreaInset.md
+++ b/packages/react-simplikit/src/utils/getSafeAreaInset/getSafeAreaInset.md
@@ -24,6 +24,8 @@ function getSafeAreaInset(): SafeAreaInset;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/utils/getSafeAreaInset/ko/getSafeAreaInset.md
+++ b/packages/react-simplikit/src/utils/getSafeAreaInset/ko/getSafeAreaInset.md
@@ -18,6 +18,8 @@ function getSafeAreaInset(): SafeAreaInset;
 
 ### 파라미터
 
+이 함수는 파라미터를 받지 않아요.
+
 ### 반환 값
 
 <Interface

--- a/packages/react-simplikit/src/utils/isKeyboardVisible/isKeyboardVisible.md
+++ b/packages/react-simplikit/src/utils/isKeyboardVisible/isKeyboardVisible.md
@@ -12,6 +12,8 @@ function isKeyboardVisible(): boolean;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/utils/isKeyboardVisible/ko/isKeyboardVisible.md
+++ b/packages/react-simplikit/src/utils/isKeyboardVisible/ko/isKeyboardVisible.md
@@ -10,6 +10,8 @@ function isKeyboardVisible(): boolean;
 
 ### 파라미터
 
+이 함수는 파라미터를 받지 않아요.
+
 ### 반환 값
 
 <Interface

--- a/packages/react-simplikit/src/utils/isServer/isServer.md
+++ b/packages/react-simplikit/src/utils/isServer/isServer.md
@@ -10,6 +10,8 @@ function isServer(): boolean;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 <Interface

--- a/packages/react-simplikit/src/utils/isServer/ko/isServer.md
+++ b/packages/react-simplikit/src/utils/isServer/ko/isServer.md
@@ -10,6 +10,8 @@ function isServer(): boolean;
 
 ### 파라미터
 
+이 함수는 파라미터를 받지 않아요.
+
 ### 반환 값
 
 <Interface


### PR DESCRIPTION
# Overview

The documentation currently displays default text inconsistently for functions without parameters.
To make this behavior consistent, I updated the documentation generation logic to include a default message whenever the JSDoc has no `param` tags.

