### PR TITLE
docs(useBodyScrollLock): align English and plugin docs with Korean docs

### DIFF
--- a/packages/plugin/skills/react-simplikit/references/useBodyScrollLock.md
+++ b/packages/plugin/skills/react-simplikit/references/useBodyScrollLock.md
@@ -1,8 +1,6 @@
 # useBodyScrollLock
 
-`useBodyScrollLock` is a React hook that locks body scroll while the component is mounted. It automatically locks on mount and unlocks on unmount.
-
-**Note:** For multiple overlapping modals, use a single lock at the parent level.
+`useBodyScrollLock` is a React hook that locks body scroll while the component is mounted. It automatically locks on mount and unlocks on unmount. It is useful for overlay components such as modals and drawers that need to prevent background scrolling.
 
 ## Interface
 
@@ -12,18 +10,28 @@ function useBodyScrollLock(): void;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 This hook does not return anything.
 
 ## Example
 
+### Basic Usage
+
 ```tsx
 function Modal() {
   useBodyScrollLock();
   return <div className="modal">Modal content</div>;
 }
+```
 
+### Multiple Modals - Single Lock Pattern
+
+When multiple modals overlap, use a single lock at the parent level instead of applying a separate lock to each modal.
+
+```tsx
 // Multiple modals - single lock pattern
 function BodyScrollLock() {
   useBodyScrollLock();
@@ -42,3 +50,10 @@ function App() {
   );
 }
 ```
+
+## Notes
+
+- **SSR safety**: Because this hook uses `useEffect`, it runs only on the client, making it safe to use with server-side rendering (SSR).
+- **Automatic cleanup**: When the component unmounts, the scroll lock is automatically released, ensuring proper cleanup.
+- **Multiple modals**: When multiple modals overlap, do not apply a separate lock to each modal. Implement a single lock at the parent level instead. This prevents conflicts and ensures consistent behavior.
+- **Browser support**: This hook works in all modern browsers that support the CSS changes applied by the `enableBodyScrollLock` and `disableBodyScrollLock` utilities.

--- a/packages/react-simplikit/src/hooks/useBodyScrollLock/useBodyScrollLock.md
+++ b/packages/react-simplikit/src/hooks/useBodyScrollLock/useBodyScrollLock.md
@@ -1,8 +1,6 @@
 # useBodyScrollLock
 
-`useBodyScrollLock` is a React hook that locks body scroll while the component is mounted. It automatically locks on mount and unlocks on unmount.
-
-**Note:** For multiple overlapping modals, use a single lock at the parent level.
+`useBodyScrollLock` is a React hook that locks body scroll while the component is mounted. It automatically locks on mount and unlocks on unmount. It is useful for overlay components such as modals and drawers that need to prevent background scrolling.
 
 ## Interface
 
@@ -12,18 +10,28 @@ function useBodyScrollLock(): void;
 
 ### Parameters
 
+This function does not accept any parameters.
+
 ### Return Value
 
 This hook does not return anything.
 
 ## Example
 
+### Basic Usage
+
 ```tsx
 function Modal() {
   useBodyScrollLock();
   return <div className="modal">Modal content</div>;
 }
+```
 
+### Multiple Modals - Single Lock Pattern
+
+When multiple modals overlap, use a single lock at the parent level instead of applying a separate lock to each modal.
+
+```tsx
 // Multiple modals - single lock pattern
 function BodyScrollLock() {
   useBodyScrollLock();
@@ -42,3 +50,10 @@ function App() {
   );
 }
 ```
+
+## Notes
+
+- **SSR safety**: Because this hook uses `useEffect`, it runs only on the client, making it safe to use with server-side rendering (SSR).
+- **Automatic cleanup**: When the component unmounts, the scroll lock is automatically released, ensuring proper cleanup.
+- **Multiple modals**: When multiple modals overlap, do not apply a separate lock to each modal. Implement a single lock at the parent level instead. This prevents conflicts and ensures consistent behavior.
+- **Browser support**: This hook works in all modern browsers that support the CSS changes applied by the `enableBodyScrollLock` and `disableBodyScrollLock` utilities.


### PR DESCRIPTION
# Overview

The Korean and English documentation for `useBodyScrollLock` differ in content and should be aligned for consistency.
The Korean documentation also seems more relevant and informative, particularly with examples such as using multiple modals.
