### PR TITLE
docs(useConditionalEffect): add line breaks to the condition description

### DIFF
--- a/packages/plugin/skills/react-simplikit/references/useConditionalEffect.md
+++ b/packages/plugin/skills/react-simplikit/references/useConditionalEffect.md
@@ -32,7 +32,7 @@ function useConditionalEffect(
   required
   name="condition"
   type="(prevDeps: T | undefined, currentDeps: T) => boolean"
-  description="Function that determines if the effect should run based on previous and current deps. - On the initial render, <code>prevDeps</code> will be <code>undefined</code>. Your <code>condition</code> function should handle this case. - If you want your effect to run on the initial render, return <code>true</code> when <code>prevDeps</code> is <code>undefined</code>. - If you don't want your effect to run on the initial render, return <code>false</code> when <code>prevDeps</code> is <code>undefined</code>."
+  description="Function that determines if the effect should run based on previous and current deps. <br />- On the initial render, <code>prevDeps</code> will be <code>undefined</code>. Your <code>condition</code> function should handle this case. <br />- If you want your effect to run on the initial render, return <code>true</code> when <code>prevDeps</code> is <code>undefined</code>. <br />- If you don't want your effect to run on the initial render, return <code>false</code> when <code>prevDeps</code> is <code>undefined</code>."
 />
 
 ### Return Value

--- a/packages/react-simplikit/src/hooks/useConditionalEffect/useConditionalEffect.md
+++ b/packages/react-simplikit/src/hooks/useConditionalEffect/useConditionalEffect.md
@@ -32,7 +32,7 @@ function useConditionalEffect(
   required
   name="condition"
   type="(prevDeps: T | undefined, currentDeps: T) => boolean"
-  description="Function that determines if the effect should run based on previous and current deps. - On the initial render, <code>prevDeps</code> will be <code>undefined</code>. Your <code>condition</code> function should handle this case. - If you want your effect to run on the initial render, return <code>true</code> when <code>prevDeps</code> is <code>undefined</code>. - If you don't want your effect to run on the initial render, return <code>false</code> when <code>prevDeps</code> is <code>undefined</code>."
+  description="Function that determines if the effect should run based on previous and current deps. <br />- On the initial render, <code>prevDeps</code> will be <code>undefined</code>. Your <code>condition</code> function should handle this case. <br />- If you want your effect to run on the initial render, return <code>true</code> when <code>prevDeps</code> is <code>undefined</code>. <br />- If you don't want your effect to run on the initial render, return <code>false</code> when <code>prevDeps</code> is <code>undefined</code>."
 />
 
 ### Return Value

--- a/packages/react-simplikit/src/hooks/useConditionalEffect/useConditionalEffect.ts
+++ b/packages/react-simplikit/src/hooks/useConditionalEffect/useConditionalEffect.ts
@@ -7,10 +7,11 @@ import { type DependencyList, type EffectCallback, useCallback, useEffect, useRe
  *
  * @param {EffectCallback} effect - The effect callback to run.
  * @param {DependencyList} deps - Dependencies array, similar to useEffect.
- * @param {(prevDeps: T | undefined, currentDeps: T) => boolean} condition - Function that determines if the effect should run based on previous and current deps.
- * - On the initial render, `prevDeps` will be `undefined`. Your `condition` function should handle this case.
- * - If you want your effect to run on the initial render, return `true` when `prevDeps` is `undefined`.
- * - If you don't want your effect to run on the initial render, return `false` when `prevDeps` is `undefined`.
+ * @param {(prevDeps: T | undefined, currentDeps: T) => boolean} condition
+ * Function that determines if the effect should run based on previous and current deps.
+ * -- On the initial render, `prevDeps` will be `undefined`. Your `condition` function should handle this case.
+ * -- If you want your effect to run on the initial render, return `true` when `prevDeps` is `undefined`.
+ * -- If you don't want your effect to run on the initial render, return `false` when `prevDeps` is `undefined`.
  *
  * @example
  * import { useConditionalEffect } from 'react-simplikit';


### PR DESCRIPTION
# Overview

### Before

It seems the items marked with `-` are intended to appear on separate lines.
They’re separated that way in the Korean documentation, but that formatting doesn’t seem to be reflected in the English documentation.

<img width="507" height="398" alt="Screenshot 2026-09-12 at 1 05 06 AM" src="https://github.com/user-attachments/assets/ef443b63-f5b7-46af-a6e2-8d331b72021a" />

### After

<img width="613" height="490" alt="Screenshot 2026-09-12 at 1 06 15 AM" src="https://github.com/user-attachments/assets/5bfea623-12cd-4aa5-bec2-82cf583fdefb" />

