### PR TITLE
docs: improve guides, AI integration and SEO

### DIFF
--- a/.scripts/commands/generateReferenceIndex/index.ts
+++ b/.scripts/commands/generateReferenceIndex/index.ts
@@ -81,7 +81,10 @@ function renderPage(locale: LocaleDefinition, sections: IndexSection[]): string 
     ...(hasFallback ? ['untranslated: true', 'sourceLocale: en'] : []),
     '---',
   ];
-  const body = [`# ${locale.themeStrings.referenceLabel}`, ...sections.map(renderSection)];
+  const prefix = locale.path === '' ? '' : `/${locale.path}`;
+  const guides = locale.themeStrings.guidePages;
+  const navigation = `[${guides.installation}](${prefix}/installation) · [${guides.useCases}](${prefix}/use-cases) · [${guides.aiIntegration}](${prefix}/ai-integration)`;
+  const body = [`# ${locale.themeStrings.referenceLabel}`, navigation, ...sections.map(renderSection)];
 
   return `${frontmatter.join('\n')}\n\n${body.join('\n\n')}\n`;
 }

--- a/.scripts/documentationExamples.spec.ts
+++ b/.scripts/documentationExamples.spec.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import * as React from 'react';
+import * as jsxRuntime from 'react/jsx-runtime';
+import { renderToString } from 'react-dom/server';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+import { afterEach, expect, it, vi } from 'vitest';
+
+import * as simplikit from '../packages/react-simplikit/src/index.ts';
+
+function loadExample(file: string, name: string): React.ComponentType {
+  const markdown = readFileSync(file, 'utf8');
+  const blocks = [...markdown.matchAll(/```tsx\n([\s\S]*?)\n```/g)].map(match => match[1]);
+  const source = blocks.find(block => block.includes(`function ${name}(`));
+  if (source == null) {
+    throw new Error(`${file} has no ${name} example`);
+  }
+  const { outputText } = ts.transpileModule(`${source}\nexport { ${name} };`, {
+    compilerOptions: { jsx: ts.JsxEmit.ReactJSX, module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+  });
+  const modules: Record<string, unknown> = {
+    react: React,
+    'react/jsx-runtime': jsxRuntime,
+    'react-simplikit': simplikit,
+  };
+  const exports: Record<string, React.ComponentType> = {};
+  // Execute the actual documented snippet with the current public API, not a copied fixture.
+  new Function('require', 'exports', outputText)((id: string) => {
+    if (!(id in modules)) {
+      throw new Error(`Unexpected example import: ${id}`);
+    }
+    return modules[id];
+  }, exports);
+  return exports[name];
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+for (const locale of ['', 'ko/', 'ja/', 'zh-Hans/', 'es/']) {
+  const file = `docs/${locale}use-cases.md`;
+
+  it(`${locale || 'en'} details example toggles content and expanded state`, () => {
+    const Details = loadExample(file, 'Details');
+    expect(renderToString(React.createElement(Details))).toContain('aria-expanded="false"');
+    render(React.createElement(Details));
+    const button = screen.getByRole('button', { name: 'Details' });
+    fireEvent.click(button);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Delivery takes 3–5 days.')).toBeDefined();
+  });
+
+  it(`${locale || 'en'} search example waits 300 ms and cancels on unmount`, () => {
+    vi.useFakeTimers();
+    const FruitSearch = loadExample(file, 'FruitSearch');
+    expect(renderToString(React.createElement(FruitSearch))).toContain('Orange');
+    const view = render(React.createElement(FruitSearch));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'ap' } });
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.getAllByRole('listitem').map(item => item.textContent)).toEqual(['Apple']);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'ba' } });
+    view.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+}
+
+for (const locale of ['', 'ko/']) {
+  for (const hook of ['useDebounce', 'useDebouncedValue']) {
+    it(`${locale || 'en'} ${hook} API example renders and delays the displayed query`, () => {
+      vi.useFakeTimers();
+      const Example = loadExample(`packages/react-simplikit/src/hooks/${hook}/${locale}${hook}.md`, 'SearchInput');
+      expect(renderToString(React.createElement(Example))).toContain('<output');
+      render(React.createElement(Example));
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'react' } });
+      expect(screen.getByRole('status').textContent).toBe('');
+      act(() => vi.advanceTimersByTime(300));
+      expect(screen.getByRole('status').textContent).toBe('react');
+      if (hook === 'useDebounce') {
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: 'cancelled' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel pending update' }));
+        act(() => vi.advanceTimersByTime(300));
+        expect(screen.getByRole('status').textContent).toBe('react');
+      }
+    });
+  }
+}

--- a/.scripts/utils/assertLlmsOutput.ts
+++ b/.scripts/utils/assertLlmsOutput.ts
@@ -43,6 +43,12 @@ export async function assertLlmsOutput({ buildOutputDirectory, root }: AssertLlm
     );
   }
 
+  for (const guide of ['installation', 'use-cases', 'ai-integration']) {
+    assert.ok(links.includes(`https://react-simplikit.slash.page/${guide}.md`), `llms.txt must link ${guide}`);
+    const markdown = await fs.readFile(path.join(buildOutputDirectory, `${guide}.md`), 'utf8');
+    assert.ok(markdown.includes('# '), `${guide}.md must contain readable documentation`);
+  }
+
   const llmsFullTxt = await fs.readFile(path.join(buildOutputDirectory, 'llms-full.txt'), 'utf8');
   assert.equal(llmsFullTxt.includes('# useDebounce'), true, 'llms-full.txt must inline the page contents');
 

--- a/.scripts/utils/assertSeoOutput.ts
+++ b/.scripts/utils/assertSeoOutput.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import { SITE_ORIGIN } from '../../.vitepress/shared.mts';
+
+const { JSDOM } = createRequire(import.meta.url)('jsdom') as {
+  JSDOM: new (html: string, options?: { contentType: string }) => { window: Window };
+};
+
+/** Checks the rendered output, including VitePress's rewrites and generated fallbacks. */
+export async function assertSeoOutput(buildOutputDirectory: string): Promise<void> {
+  const sitemap = new JSDOM(await readFile(path.join(buildOutputDirectory, 'sitemap.xml'), 'utf8'), {
+    contentType: 'application/xml',
+  });
+  const entries = Array.from(sitemap.window.document.querySelectorAll('url'));
+  const urls = entries.map(entry => entry.querySelector('loc')!.textContent!);
+  assert.ok(urls.length > 0, 'the sitemap must contain canonical pages');
+  assert.equal(new Set(urls).size, urls.length, 'sitemap URLs must be unique');
+
+  for (const entry of entries) {
+    const url = entry.querySelector('loc')!.textContent!;
+    assert.equal(/\/(?:generated-locales|core|mobile)\//.test(url), false, `unexpected sitemap URL: ${url}`);
+    for (const alternate of Array.from(entry.getElementsByTagNameNS('http://www.w3.org/1999/xhtml', 'link'))) {
+      assert.ok(urls.includes(alternate.getAttribute('href')!), `${url} links a non-canonical alternate`);
+    }
+  }
+
+  const cases = [
+    ['', ''],
+    ['ko/', 'ko/'],
+    ['use-cases.html', 'use-cases.html'],
+    ['ko/use-cases.html', 'ko/use-cases.html'],
+    ['ja/use-cases.html', 'ja/use-cases.html'],
+    ['zh-Hans/use-cases.html', 'zh-Hans/use-cases.html'],
+    ['es/use-cases.html', 'es/use-cases.html'],
+    ['hooks/useDebounce.html', 'hooks/useDebounce.html'],
+    ['ko/hooks/useDebounce.html', 'ko/hooks/useDebounce.html'],
+    ['ja/hooks/useDebounce.html', 'hooks/useDebounce.html'],
+    ['ko/untranslated-fallback-fixture.html', 'untranslated-fallback-fixture.html'],
+  ];
+  for (const [route, canonicalRoute] of cases) {
+    const html = await readFile(
+      path.join(buildOutputDirectory, route.endsWith('.html') ? route : `${route}index.html`),
+      'utf8'
+    );
+    const dom = new JSDOM(html.slice(0, html.indexOf('</head>') + '</head>'.length));
+    const { document } = dom.window;
+    const canonical = `${SITE_ORIGIN}/${canonicalRoute}`;
+    const canonicalLinks = document.querySelectorAll('link[rel="canonical"]');
+    assert.equal(canonicalLinks.length, 1, `${route} must have one canonical link`);
+    assert.equal(canonicalLinks[0].getAttribute('href'), canonical);
+    assert.equal(urls.includes(`${SITE_ORIGIN}/${route}`), route === canonicalRoute, `${route} sitemap membership`);
+
+    const description = document.querySelector('meta[name="description"]')?.getAttribute('content');
+    assert.ok(
+      description != null && description.length > 0 && description !== 'A VitePress site',
+      `${route} description`
+    );
+    for (const [selector, expected] of [
+      ['meta[property="og:url"]', canonical],
+      ['meta[property="og:title"]', document.title],
+      ['meta[name="twitter:title"]', document.title],
+      ['meta[property="og:description"]', description],
+      ['meta[name="twitter:description"]', description],
+    ]) {
+      const tags = document.querySelectorAll(selector);
+      assert.equal(tags.length, 1, `${route} must have one ${selector}`);
+      assert.equal(tags[0].getAttribute('content'), expected, `${route} ${selector}`);
+    }
+    if (route === 'ko/untranslated-fallback-fixture.html') {
+      assert.equal(description, 'Read React and hooks with useToggle. Choose a hook for your app.');
+    }
+    dom.window.close();
+  }
+
+  for (const [route, languages] of [
+    ['use-cases.html', ['en', 'ko', 'ja', 'zh-Hans', 'es']],
+    ['hooks/useDebounce.html', ['en', 'ko']],
+  ] as const) {
+    for (const language of languages) {
+      const url = `${SITE_ORIGIN}/${language === 'en' ? '' : `${language}/`}${route}`;
+      const entry = entries.find(item => item.querySelector('loc')!.textContent === url);
+      assert.ok(entry, `${url} must be indexed`);
+      const alternates = Array.from(entry.getElementsByTagNameNS('http://www.w3.org/1999/xhtml', 'link'));
+      assert.deepEqual(alternates.map(link => link.getAttribute('hreflang')).sort(), [...languages].sort());
+    }
+  }
+  sitemap.window.close();
+
+  const installation = new JSDOM(await readFile(path.join(buildOutputDirectory, 'installation.html'), 'utf8'));
+  assert.equal(
+    installation.window.document.querySelector('meta[name="description"]')?.getAttribute('content'),
+    'How to install react-simplikit'
+  );
+  installation.window.close();
+  assert.equal(urls.includes(`${SITE_ORIGIN}/404.html`), false);
+  console.log('SEO metadata, canonical URLs and translated sitemap alternates passed');
+}

--- a/.scripts/verifyDocs.ts
+++ b/.scripts/verifyDocs.ts
@@ -35,7 +35,14 @@ for (const name of publicExports) {
 // name behind and nothing else reads them. Both inline code and reference links count.
 const exportNames = new Set(publicExports);
 const handWrittenPages = await glob(
-  ['README*.md', 'packages/react-simplikit/README*.md', 'docs/mobile-web.md', 'docs/*/mobile-web.md'],
+  [
+    'README*.md',
+    'packages/react-simplikit/README*.md',
+    'docs/mobile-web.md',
+    'docs/*/mobile-web.md',
+    'docs/use-cases.md',
+    'docs/*/use-cases.md',
+  ],
   { cwd: root }
 );
 const exportMentions = [

--- a/.scripts/verifyDocsI18n.ts
+++ b/.scripts/verifyDocsI18n.ts
@@ -17,6 +17,7 @@ import {
 import { packageSourceRoot } from '../.vitepress/shared.mts';
 
 import { assertLlmsOutput } from './utils/assertLlmsOutput.ts';
+import { assertSeoOutput } from './utils/assertSeoOutput.ts';
 import { execWithOutput } from './utils/execWithOutput.ts';
 import { getRootPath } from './utils/getRootPath.ts';
 
@@ -91,7 +92,10 @@ const buildOutputDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'react-simp
 // Korean translates every routed English document, so its fallback path only has a route to
 // render on while these English-only fixtures exist. Japanese ships without translated API
 // reference pages, so those routes render from generated fallbacks on every build.
-await fs.writeFile(guideFixturePath, `# ${guideFixtureTitle}\n`);
+await fs.writeFile(
+  guideFixturePath,
+  `# ${guideFixtureTitle}\n\nRead **React** and [hooks](/reference) with \`useToggle\`.\nChoose a hook for your app.\n`
+);
 await fs.mkdir(hookFixtureDirectory, { recursive: true });
 await fs.writeFile(path.join(hookFixtureDirectory, `${hookFixtureName}.md`), `# ${hookFixtureName}\n`);
 
@@ -99,6 +103,7 @@ try {
   await execWithOutput('yarn', ['docs:build', '--outDir', buildOutputDirectory], { cwd: root });
 
   await assertLlmsOutput({ buildOutputDirectory, root });
+  await assertSeoOutput(buildOutputDirectory);
 
   // The redirect stubs are the only thing keeping pre-flattening URLs alive, and a
   // broken route filter would silently emit none of them.

--- a/.scripts/verifyDocsI18n.ts
+++ b/.scripts/verifyDocsI18n.ts
@@ -158,6 +158,18 @@ try {
   // pointing at a page that does not exist.
   for (const locale of ['', ...localeDirectories]) {
     const referencePage = await fs.readFile(path.join(buildOutputDirectory, locale, 'reference.html'), 'utf8');
+    const prefix = locale === '' ? '' : `/${locale}`;
+    for (const page of ['intro', 'installation', 'reference']) {
+      const html = await fs.readFile(path.join(buildOutputDirectory, locale, `${page}.html`), 'utf8');
+      assert.ok(html.includes(`href="${prefix}/use-cases.html"`), `${locale}/${page} must link the use-case guide`);
+    }
+    for (const page of ['use-cases', 'ai-integration']) {
+      const html = await fs.readFile(path.join(buildOutputDirectory, locale, `${page}.html`), 'utf8');
+      const definition = Object.values(localeDefinitions).find(item => item.path === locale);
+      assert.ok(definition);
+      assert.equal(html.includes(definition.untranslatedNotice), false, `${locale}/${page} must be translated`);
+    }
+
     const renderedLinks = [...referencePage.matchAll(/<li><a href="[^"]*\/(?:hooks|components|utils)\/[^"]+"/g)];
     assert.equal(
       renderedLinks.length,
@@ -228,6 +240,7 @@ const unregisteredLocaleFixture = {
       intro: 'Introdução',
       whyReactSimplikitMatters: 'Por que o react-simplikit importa',
       installation: 'Instalação',
+      useCases: 'Casos de uso comuns',
       aiIntegration: 'Integração com IA',
       designPrinciples: 'Princípios de design',
       mobileWeb: 'Web móvel',
@@ -243,7 +256,7 @@ const unregisteredConfig = buildLocaleConfig(unregisteredLocaleFixture);
 assert.equal(unregisteredConfig.lang, 'pt-BR');
 const unregisteredConfigNav = unregisteredConfig.themeConfig?.nav ?? [];
 assert.deepEqual(unregisteredConfigNav[0], { text: 'Início', link: '/pt-BR/' });
-assert.deepEqual(unregisteredConfigNav[1], { text: 'Guide', link: '/pt-BR/intro' });
+assert.deepEqual(unregisteredConfigNav[1], { text: 'Guia', link: '/pt-BR/intro' });
 assert.equal((unregisteredConfigNav[2] as DefaultTheme.NavItemWithLink).text, 'Referência');
 assert.equal((unregisteredConfigNav[2] as DefaultTheme.NavItemWithLink).link, '/pt-BR/reference');
 assert.deepEqual(Object.keys(unregisteredConfig.themeConfig?.sidebar ?? {}), ['/pt-BR/']);
@@ -254,7 +267,7 @@ const rootConfig = buildLocaleConfig(localeDefinitions.root);
 
 const koConfigNav = koConfig.themeConfig?.nav ?? [];
 assert.deepEqual(koConfigNav[0], { text: '홈', link: '/ko/' });
-assert.deepEqual(koConfigNav[1], { text: 'Guide', link: '/ko/intro' });
+assert.deepEqual(koConfigNav[1], { text: '가이드', link: '/ko/intro' });
 assert.equal((koConfigNav[2] as DefaultTheme.NavItemWithLink).text, '레퍼런스');
 assert.equal((koConfigNav[2] as DefaultTheme.NavItemWithLink).link, '/ko/reference');
 assert.deepEqual((koConfig.themeConfig?.sidebar as Record<string, DefaultTheme.SidebarItem[]>)['/ko/'][0], {
@@ -263,6 +276,7 @@ assert.deepEqual((koConfig.themeConfig?.sidebar as Record<string, DefaultTheme.S
     { text: '소개', link: '/ko/intro' },
     { text: 'react-simplikit, 선택의 이유', link: '/ko/why-react-simplikit-matters' },
     { text: '설치하기', link: '/ko/installation' },
+    { text: '문제별 사용법', link: '/ko/use-cases' },
     { text: 'AI 연동', link: '/ko/ai-integration' },
     { text: '설계 원칙', link: '/ko/design-principles' },
     { text: '모바일 웹', link: '/ko/mobile-web' },
@@ -318,7 +332,7 @@ const jaConfig = buildLocaleConfig(localeDefinitions.ja);
 assert.equal(jaConfig.lang, 'ja');
 const jaConfigNav = jaConfig.themeConfig?.nav ?? [];
 assert.deepEqual(jaConfigNav[0], { text: 'ホーム', link: '/ja/' });
-assert.deepEqual(jaConfigNav[1], { text: 'Guide', link: '/ja/intro' });
+assert.deepEqual(jaConfigNav[1], { text: 'ガイド', link: '/ja/intro' });
 assert.equal((jaConfigNav[2] as DefaultTheme.NavItemWithLink).text, 'リファレンス');
 assert.equal((jaConfigNav[2] as DefaultTheme.NavItemWithLink).link, '/ja/reference');
 assert.equal(jaConfig.themeConfig?.editLink?.text, 'GitHub で編集する');
@@ -333,7 +347,7 @@ const zhHansConfig = buildLocaleConfig(localeDefinitions['zh-Hans']);
 assert.equal(zhHansConfig.lang, 'zh-Hans');
 const zhHansConfigNav = zhHansConfig.themeConfig?.nav ?? [];
 assert.deepEqual(zhHansConfigNav[0], { text: '首页', link: '/zh-Hans/' });
-assert.deepEqual(zhHansConfigNav[1], { text: 'Guide', link: '/zh-Hans/intro' });
+assert.deepEqual(zhHansConfigNav[1], { text: '指南', link: '/zh-Hans/intro' });
 assert.equal((zhHansConfigNav[2] as DefaultTheme.NavItemWithLink).text, '参考');
 assert.equal((zhHansConfigNav[2] as DefaultTheme.NavItemWithLink).link, '/zh-Hans/reference');
 assert.equal(zhHansConfig.themeConfig?.editLink?.text, '在 GitHub 上编辑此页');
@@ -348,7 +362,7 @@ const esConfig = buildLocaleConfig(localeDefinitions.es);
 assert.equal(esConfig.lang, 'es');
 const esConfigNav = esConfig.themeConfig?.nav ?? [];
 assert.deepEqual(esConfigNav[0], { text: 'Inicio', link: '/es/' });
-assert.deepEqual(esConfigNav[1], { text: 'Guide', link: '/es/intro' });
+assert.deepEqual(esConfigNav[1], { text: 'Guía', link: '/es/intro' });
 assert.equal((esConfigNav[2] as DefaultTheme.NavItemWithLink).text, 'Referencia');
 assert.equal((esConfigNav[2] as DefaultTheme.NavItemWithLink).link, '/es/reference');
 assert.equal(esConfig.themeConfig?.editLink?.text, 'Editar esta página en GitHub');

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -5,6 +5,12 @@ import { generatedRewrites, localeDefinitions, rewrites } from './locales.mts';
 import { writeLegacyRedirectStubs } from './libs/legacyRedirects.mts';
 import { SITE_ORIGIN } from './shared.mts';
 
+const fallbackUrls = new Set<string>();
+
+function pageUrl(relativePath: string): string {
+  return relativePath.replace(/(^|\/)index\.md$/, '$1').replace(/\.md$/, '.html');
+}
+
 const locales = Object.fromEntries(
   Object.entries(localeDefinitions).map(([code, definition]) => [
     code,
@@ -78,7 +84,63 @@ Guidelines for AI agents:
     ],
   },
   rewrites: { ...rewrites, ...generatedRewrites },
-  sitemap: { hostname: SITE_ORIGIN },
+  sitemap: {
+    hostname: SITE_ORIGIN,
+    transformItems: items =>
+      items
+        .filter(item => !fallbackUrls.has(item.url))
+        .map(item => ({ ...item, links: item.links?.filter(link => !fallbackUrls.has(link.url)) })),
+  },
+  markdown: {
+    config(md) {
+      md.core.ruler.after('inline', 'page-description', state => {
+        if (state.inlineMode) {
+          return;
+        }
+        const { frontmatter } = state.env as {
+          frontmatter: { description?: string; hero?: { text?: string } };
+        };
+        if (frontmatter.description != null) {
+          return;
+        }
+
+        const paragraph = state.tokens.findIndex(token => token.type === 'paragraph_open' && token.level === 0);
+        const text = state.tokens[paragraph + 1]?.children
+          ?.map(token => {
+            if (token.type === 'text' || token.type === 'code_inline') {
+              return token.content;
+            }
+            return token.type === 'softbreak' || token.type === 'hardbreak' ? ' ' : '';
+          })
+          .join('');
+        frontmatter.description = frontmatter.hero?.text ?? text?.replace(/\s+/g, ' ').trim();
+      });
+    },
+  },
+  transformPageData(pageData) {
+    const url = pageUrl(pageData.relativePath);
+    const isFallback = pageData.frontmatter.untranslated === true;
+    if (isFallback) {
+      fallbackUrls.add(url);
+    } else {
+      fallbackUrls.delete(url);
+    }
+    const canonical = `${SITE_ORIGIN}/${isFallback ? url.slice(url.indexOf('/') + 1) : url}`;
+    const title =
+      pageData.title === '' || pageData.title === 'react-simplikit'
+        ? 'react-simplikit'
+        : `${pageData.title} | react-simplikit`;
+    const head: HeadConfig[] = [
+      ['link', { rel: 'canonical', href: canonical }],
+      ['meta', { property: 'og:url', content: canonical }],
+      ['meta', { property: 'og:title', content: title }],
+      ['meta', { property: 'og:description', content: pageData.description }],
+      ['meta', { name: 'twitter:title', content: title }],
+      ['meta', { name: 'twitter:description', content: pageData.description }],
+    ];
+    pageData.frontmatter.head ??= [];
+    pageData.frontmatter.head.push(...head);
+  },
   buildEnd: async siteConfig => {
     const count = writeLegacyRedirectStubs(siteConfig.outDir);
     console.log(`legacy redirect stubs: ${count}`);
@@ -95,24 +157,11 @@ Guidelines for AI agents:
     ['meta', { name: 'keywords', content: 'react, hooks, utility, library, react-simplikit, mobile' }],
     ['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1' }],
     ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:title', content: 'react-simplikit' }],
-    ['meta', { property: 'og:description', content: 'Lightweight and powerful React utility library' }],
     ['meta', { property: 'og:site_name', content: 'react-simplikit' }],
     ['meta', { property: 'og:image', content: `${SITE_ORIGIN}/images/og.png` }],
     ['meta', { name: 'twitter:image', content: `${SITE_ORIGIN}/images/og.png` }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
   ],
-  transformHead: ({ pageData }) => {
-    const head: HeadConfig[] = [];
-    const title = pageData.frontmatter.title || pageData.title || 'react-simplikit';
-    const description =
-      pageData.frontmatter.description || pageData.description || 'Lightweight and powerful React utility library';
-
-    head.push(['meta', { property: 'og:title', content: title }]);
-    head.push(['meta', { property: 'og:description', content: description }]);
-
-    return head;
-  },
   themeConfig: {
     logo: '/images/logo.svg',
     search: {

--- a/.vitepress/libs/buildLocaleConfig.mts
+++ b/.vitepress/libs/buildLocaleConfig.mts
@@ -25,7 +25,7 @@ export function buildLocaleConfig(
     themeConfig: {
       nav: [
         { text: strings.homeNavLabel, link: `${prefix}/` },
-        { text: 'Guide', link: `${prefix}/intro` },
+        { text: strings.guideLabel, link: `${prefix}/intro` },
         { text: strings.referenceLabel, link: `${prefix}/reference` },
       ],
       sidebar: {
@@ -39,6 +39,7 @@ export function buildLocaleConfig(
                 link: `${prefix}/why-react-simplikit-matters`,
               },
               { text: strings.guidePages.installation, link: `${prefix}/installation` },
+              { text: strings.guidePages.useCases, link: `${prefix}/use-cases` },
               { text: strings.guidePages.aiIntegration, link: `${prefix}/ai-integration` },
               { text: strings.guidePages.designPrinciples, link: `${prefix}/design-principles` },
               { text: strings.guidePages.mobileWeb, link: `${prefix}/mobile-web` },

--- a/.vitepress/locales.mts
+++ b/.vitepress/locales.mts
@@ -12,6 +12,7 @@ type GuidePageTitles = {
   intro: string;
   whyReactSimplikitMatters: string;
   installation: string;
+  useCases: string;
   aiIntegration: string;
   designPrinciples: string;
   mobileWeb: string;

--- a/.vitepress/locales/en.mts
+++ b/.vitepress/locales/en.mts
@@ -11,6 +11,7 @@ export const en: LocaleThemeStrings = {
     intro: 'Introduction',
     whyReactSimplikitMatters: 'Why react-simplikit matters',
     installation: 'Installation',
+    useCases: 'Common use cases',
     aiIntegration: 'AI Integration',
     designPrinciples: 'Design Principles',
     mobileWeb: 'Mobile Web',

--- a/.vitepress/locales/es.mts
+++ b/.vitepress/locales/es.mts
@@ -11,6 +11,7 @@ export const es: LocaleThemeStrings = {
     intro: 'Introducción',
     whyReactSimplikitMatters: 'Por qué importa react-simplikit',
     installation: 'Instalación',
+    useCases: 'Casos de uso comunes',
     aiIntegration: 'Integración con IA',
     designPrinciples: 'Principios de diseño',
     mobileWeb: 'Web móvil',

--- a/.vitepress/locales/ja.mts
+++ b/.vitepress/locales/ja.mts
@@ -11,6 +11,7 @@ export const ja: LocaleThemeStrings = {
     intro: '紹介',
     whyReactSimplikitMatters: 'なぜ react-simplikit なのか',
     installation: 'インストール',
+    useCases: '用途別の使い方',
     aiIntegration: 'AI 連携',
     designPrinciples: '設計原則',
     mobileWeb: 'モバイル Web',

--- a/.vitepress/locales/ko.mts
+++ b/.vitepress/locales/ko.mts
@@ -11,6 +11,7 @@ export const ko: LocaleThemeStrings = {
     intro: '소개',
     whyReactSimplikitMatters: 'react-simplikit, 선택의 이유',
     installation: '설치하기',
+    useCases: '문제별 사용법',
     aiIntegration: 'AI 연동',
     designPrinciples: '설계 원칙',
     mobileWeb: '모바일 웹',

--- a/.vitepress/locales/zh-Hans.mts
+++ b/.vitepress/locales/zh-Hans.mts
@@ -11,6 +11,7 @@ export const zhHans: LocaleThemeStrings = {
     intro: '简介',
     whyReactSimplikitMatters: '为什么选择 react-simplikit',
     installation: '安装',
+    useCases: '常见使用场景',
     aiIntegration: 'AI 集成',
     designPrinciples: '设计原则',
     mobileWeb: '移动端 Web',

--- a/README-es.md
+++ b/README-es.md
@@ -29,6 +29,8 @@ npm install react-simplikit
 
 ## Inicio rápido
 
+Usa `useDebounce` para llamar a tu función de búsqueda cuando el usuario deje de escribir durante 300 ms. En este ejemplo, `searchAPI` es la función de búsqueda que proporciona tu aplicación.
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -58,6 +60,8 @@ La función con debounce expone `.cancel()`, y las llamadas pendientes se cancel
 
 ### Mantener un elemento fijo por encima del teclado en pantalla
 
+Aplica el estilo que devuelve `useAvoidKeyboard` para mover un campo de entrada fijo por encima del teclado en pantalla cuando se abre.
+
 ```tsx
 import { useAvoidKeyboard } from 'react-simplikit';
 
@@ -71,6 +75,16 @@ function ChatInput() {
   );
 }
 ```
+
+## Integración con IA
+
+Ayuda a tu asistente de programación con IA a encontrar Hooks, componentes y utilidades existentes, y a consultar las reglas de importación y SSR con la skill de agente incluida.
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+Consulta la [guía de integración con IA (en inglés)](https://react-simplikit.slash.page/ai-integration.html) para conocer los detalles de configuración. Los agentes también pueden usar [llms.txt](https://react-simplikit.slash.page/llms.txt) para encontrar documentación de las API.
 
 ## Documentación
 

--- a/README-es.md
+++ b/README-es.md
@@ -84,9 +84,11 @@ Ayuda a tu asistente de programación con IA a encontrar Hooks, componentes y ut
 npx skills add toss/react-simplikit --skill react-simplikit
 ```
 
-Consulta la [guía de integración con IA (en inglés)](https://react-simplikit.slash.page/ai-integration.html) para conocer los detalles de configuración. Los agentes también pueden usar [llms.txt](https://react-simplikit.slash.page/llms.txt) para encontrar documentación de las API.
+Consulta la [guía de integración con IA](https://react-simplikit.slash.page/es/ai-integration.html) para conocer los detalles de configuración. Los agentes también pueden usar [llms.txt](https://react-simplikit.slash.page/llms.txt) para encontrar documentación de las API.
 
 ## Documentación
+
+Elige un Hook según el problema que necesitas resolver en [Casos de uso comunes](https://react-simplikit.slash.page/es/use-cases.html).
 
 Consulta la documentación completa en [react-simplikit.slash.page](https://react-simplikit.slash.page/es).
 

--- a/README-ja_jp.md
+++ b/README-ja_jp.md
@@ -29,6 +29,8 @@ npm install react-simplikit
 
 ## クイックスタート
 
+`useDebounce` を使うと、ユーザーが入力を止めてから 300 ms 後に検索関数を呼び出せます。この例の `searchAPI` は、アプリケーション側で用意する検索関数です。
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -58,6 +60,8 @@ function SearchInput() {
 
 ### 固定要素をオンスクリーンキーボードの上に保つ
 
+`useAvoidKeyboard` が返すスタイルを適用すると、オンスクリーンキーボードが開いたときに固定された入力欄をキーボードの上に移動できます。
+
 ```tsx
 import { useAvoidKeyboard } from 'react-simplikit';
 
@@ -71,6 +75,16 @@ function ChatInput() {
   );
 }
 ```
+
+## AI 連携
+
+付属のエージェントスキルを使うと、AI コーディングアシスタントが既存のフック、コンポーネント、ユーティリティを探し、import と SSR のルールを確認するのに役立ちます。
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+設定方法は [AI 連携ガイド（英語）](https://react-simplikit.slash.page/ai-integration.html)をご覧ください。エージェントは [llms.txt](https://react-simplikit.slash.page/llms.txt) からも API ドキュメントを探せます。
 
 ## ドキュメント
 

--- a/README-ja_jp.md
+++ b/README-ja_jp.md
@@ -84,9 +84,11 @@ function ChatInput() {
 npx skills add toss/react-simplikit --skill react-simplikit
 ```
 
-設定方法は [AI 連携ガイド（英語）](https://react-simplikit.slash.page/ai-integration.html)をご覧ください。エージェントは [llms.txt](https://react-simplikit.slash.page/llms.txt) からも API ドキュメントを探せます。
+設定方法は [AI 連携ガイド](https://react-simplikit.slash.page/ja/ai-integration.html)をご覧ください。エージェントは [llms.txt](https://react-simplikit.slash.page/llms.txt) からも API ドキュメントを探せます。
 
 ## ドキュメント
+
+解決したい問題に合うフックは [用途別の使い方](https://react-simplikit.slash.page/ja/use-cases.html) で探せます。
 
 詳しいドキュメントは [react-simplikit.slash.page](https://react-simplikit.slash.page/ja) をご覧ください。
 

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -88,6 +88,8 @@ npx skills add toss/react-simplikit --skill react-simplikit
 
 ## 문서
 
+해결하려는 문제에 맞는 훅은 [문제별 사용법](https://react-simplikit.slash.page/ko/use-cases.html)에서 찾아보세요.
+
 자세한 문서는 [react-simplikit.slash.page](https://react-simplikit.slash.page/ko)를 참고하세요.
 
 ## 레포지토리 구조

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -29,6 +29,8 @@ npm install react-simplikit
 
 ## 빠른 시작
 
+`useDebounce`를 사용하면 사용자가 입력을 멈춘 뒤 300ms 후에 검색 함수를 호출할 수 있어요. 아래 예제의 `searchAPI`는 애플리케이션에서 제공하는 검색 함수예요.
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -58,6 +60,8 @@ function SearchInput() {
 
 ### 고정 요소를 온스크린 키보드 위에 유지하기
 
+`useAvoidKeyboard`가 반환하는 스타일을 적용하면 온스크린 키보드가 열릴 때 고정된 입력창을 키보드 위로 이동할 수 있어요.
+
 ```tsx
 import { useAvoidKeyboard } from 'react-simplikit';
 
@@ -71,6 +75,16 @@ function ChatInput() {
   );
 }
 ```
+
+## AI 연동
+
+함께 제공하는 에이전트 스킬로 AI 코딩 어시스턴트가 기존 훅·컴포넌트·유틸리티를 찾고, import와 SSR 규칙을 확인하도록 도와주세요.
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+설정 방법은 [AI 연동 가이드](https://react-simplikit.slash.page/ko/ai-integration.html)를 참고하세요. 에이전트는 [llms.txt](https://react-simplikit.slash.page/llms.txt)에서도 API 문서를 찾을 수 있어요.
 
 ## 문서
 

--- a/README-zh_hans.md
+++ b/README-zh_hans.md
@@ -29,6 +29,8 @@ npm install react-simplikit
 
 ## 快速开始
 
+使用 `useDebounce`，在用户停止输入 300 ms 后调用搜索函数。此示例中的 `searchAPI` 是由你的应用提供的搜索函数。
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -58,6 +60,8 @@ function SearchInput() {
 
 ### 让固定元素始终位于软键盘上方
 
+应用 `useAvoidKeyboard` 返回的样式，即可在软键盘弹出时将固定的输入框移到键盘上方。
+
 ```tsx
 import { useAvoidKeyboard } from 'react-simplikit';
 
@@ -71,6 +75,16 @@ function ChatInput() {
   );
 }
 ```
+
+## AI 集成
+
+使用随附的 agent skill，帮助 AI 编程助手查找现有的 Hook、组件和工具函数，并确认 import 和 SSR 规则。
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+设置方法请参阅 [AI 集成指南（英文）](https://react-simplikit.slash.page/ai-integration.html)。Agent 也可以通过 [llms.txt](https://react-simplikit.slash.page/llms.txt) 查找 API 文档。
 
 ## 文档
 

--- a/README-zh_hans.md
+++ b/README-zh_hans.md
@@ -84,9 +84,11 @@ function ChatInput() {
 npx skills add toss/react-simplikit --skill react-simplikit
 ```
 
-设置方法请参阅 [AI 集成指南（英文）](https://react-simplikit.slash.page/ai-integration.html)。Agent 也可以通过 [llms.txt](https://react-simplikit.slash.page/llms.txt) 查找 API 文档。
+设置方法请参阅 [AI 集成指南](https://react-simplikit.slash.page/zh-Hans/ai-integration.html)。Agent 也可以通过 [llms.txt](https://react-simplikit.slash.page/llms.txt) 查找 API 文档。
 
 ## 文档
+
+在[常见使用场景](https://react-simplikit.slash.page/zh-Hans/use-cases.html) 中，根据要解决的问题选择 Hook。
 
 完整文档请访问 [react-simplikit.slash.page](https://react-simplikit.slash.page/zh-Hans)。
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm install react-simplikit
 
 ## Quick Start
 
+Use `useDebounce` to call your search function after the user stops typing for 300 ms. In this example, `searchAPI` is the search function provided by your application.
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -58,6 +60,8 @@ The debounced function exposes `.cancel()`, and pending calls are cancelled auto
 
 ### Keep a fixed element above the on-screen keyboard
 
+Use the style returned by `useAvoidKeyboard` to move a fixed input above the on-screen keyboard when it opens.
+
 ```tsx
 import { useAvoidKeyboard } from 'react-simplikit';
 
@@ -71,6 +75,16 @@ function ChatInput() {
   );
 }
 ```
+
+## AI Integration
+
+Help your AI coding assistant find existing hooks, components and utilities, and check import and SSR rules with the included agent skill.
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+See the [AI Integration guide](https://react-simplikit.slash.page/ai-integration.html) for setup details. Agents can also use [llms.txt](https://react-simplikit.slash.page/llms.txt) to find API documentation.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ See the [AI Integration guide](https://react-simplikit.slash.page/ai-integration
 
 ## Documentation
 
+Choose a hook by the problem you need to solve in [Common use cases](https://react-simplikit.slash.page/use-cases.html).
+
 Visit [react-simplikit.slash.page](https://react-simplikit.slash.page) for full documentation.
 
 ## Repository Structure

--- a/docs/ai-integration.md
+++ b/docs/ai-integration.md
@@ -41,3 +41,12 @@ The documentation is also published in the formats agents read directly:
 ## Context7
 
 react-simplikit is indexed on [Context7](https://context7.com/toss/react-simplikit) as `/toss/react-simplikit`. Agents with the Context7 MCP server can query the documentation from there without any setup on your side.
+
+## Verify agent access
+
+1. Ask the agent to find an API for a concrete task, such as delaying a search callback by 300 ms, using the installed skill or [llms.txt](https://react-simplikit.slash.page/llms.txt).
+2. Have it read the linked [useDebounce Markdown reference](https://react-simplikit.slash.page/hooks/useDebounce.md), then report the import, parameters, defaults and cleanup behavior before writing code.
+3. Confirm that it uses a named import from `react-simplikit`, distinguishes a delayed callback from a delayed value, and explains that cancelling a pending callback does not abort an already-started request.
+4. Check the API against your installed package version and run the resulting code in your project. The website follows the latest documentation; a correct lookup does not prove compatibility with an older installation.
+
+If the agent cannot load its skill or access the site, give it the relevant Markdown reference directly. Installation alone does not prove that an agent read the documentation. The generated skill catalog lists API entries; use [Common use cases](/use-cases) to describe the behavior you need.

--- a/docs/es/ai-integration.md
+++ b/docs/es/ai-integration.md
@@ -1,0 +1,52 @@
+---
+description: Usar react-simplikit con agentes de programación con IA
+---
+
+# Integración con IA
+
+react-simplikit incluye recursos para que un agente de programación con IA (Claude Code, Codex, Cursor y otros) encuentre el Hook adecuado antes de escribirlo por su cuenta.
+
+## Skill de agente
+
+La skill `react-simplikit` contiene un catálogo de todos los Hooks, componentes y utilidades con una descripción de una línea, además de reglas sobre importaciones y SSR. Una vez instalada, el agente puede consultarla antes de escribir lógica de debounce, throttle, clics externos o posicionamiento sobre el teclado, y leer la referencia incluida antes de usar una API.
+
+::: code-group
+
+```sh [skills.sh]
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+```sh [Claude Code]
+claude plugin marketplace add https://github.com/toss/react-simplikit --sparse .claude-plugin packages/plugin
+claude plugin install react-simplikit@react-simplikit
+```
+
+```sh [Codex]
+codex plugin marketplace add https://github.com/toss/react-simplikit
+# then install "react-simplikit" from the plugin UI
+```
+
+:::
+
+La skill se genera a partir de estas páginas de documentación para mantenerse sincronizada con la biblioteca. Su código fuente está en [`packages/plugin`](https://github.com/toss/react-simplikit/tree/main/packages/plugin).
+
+## llms.txt
+
+La documentación también se publica en formatos que los agentes pueden leer directamente.
+
+- [`/llms.txt`](https://react-simplikit.slash.page/llms.txt) — un índice de todas las páginas con un resumen de una línea
+- [`/llms-full.txt`](https://react-simplikit.slash.page/llms-full.txt) — toda la documentación en un solo archivo
+- Cambia el sufijo de la URL de una página a `.md` para obtener Markdown sin procesar, por ejemplo: [`/hooks/useDebounce.md`](https://react-simplikit.slash.page/hooks/useDebounce.md)
+
+## Context7
+
+react-simplikit está indexado en [Context7](https://context7.com/toss/react-simplikit) como `/toss/react-simplikit`. Los agentes con el servidor MCP de Context7 pueden consultar la documentación allí sin configuración adicional por tu parte.
+
+## Verificar el acceso del agente
+
+1. Pide al agente que encuentre una API para una tarea concreta, como retrasar un callback de búsqueda 300 ms, usando la skill instalada o [llms.txt](https://react-simplikit.slash.page/llms.txt).
+2. Pídele que lea la [referencia Markdown de useDebounce](https://react-simplikit.slash.page/hooks/useDebounce.md) enlazada y que explique el import, los parámetros, los valores predeterminados y la limpieza antes de escribir código.
+3. Confirma que usa una importación con nombre desde `react-simplikit`, distingue entre retrasar un callback y retrasar un valor, y explica que cancelar un callback pendiente no aborta una solicitud ya iniciada.
+4. Comprueba que tu versión instalada del paquete ofrece esa API y ejecuta el código en tu proyecto. El sitio ofrece la documentación más reciente; encontrar la información correcta no demuestra compatibilidad con una instalación anterior.
+
+Si el agente no puede cargar su skill o acceder al sitio, proporciónale directamente la referencia Markdown correspondiente. Instalar la skill no demuestra que el agente haya leído la documentación. El catálogo generado enumera las API; usa [Casos de uso comunes](/es/use-cases) para describir el comportamiento que necesitas.

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -40,3 +40,5 @@ import { useToggle } from 'react-simplikit';
 ```
 
 Todos los Hooks admiten tree shaking, así que en tu bundle solo se incluye lo que realmente usas.
+
+Consulta [casos de uso comunes](/es/use-cases) para ver ejemplos completos, o explora la [referencia de API](/es/reference).

--- a/docs/es/intro.md
+++ b/docs/es/intro.md
@@ -121,3 +121,5 @@ En comparación con react-use, que tiene [14 dependencias](https://www.npmjs.com
 Para más información sobre react-simplikit, consulta el siguiente enlace:
 
 - [GitHub](https://github.com/toss/react-simplikit)
+
+Consulta [casos de uso comunes](/es/use-cases) para ver ejemplos completos, o explora la [referencia de API](/es/reference).

--- a/docs/es/use-cases.md
+++ b/docs/es/use-cases.md
@@ -1,0 +1,93 @@
+---
+description: Elegir una utilidad de React según el problema que necesitas resolver
+---
+
+# Casos de uso comunes
+
+Elige una API según el comportamiento que necesitas y consulta sus parámetros y casos límite en la referencia. [Instala react-simplikit](/es/installation) antes de probar los ejemplos.
+
+## Elegir una API
+
+| Problema                                 | API                                                      | Qué ofrece                                                                 |
+| ---------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Mostrar u ocultar contenido              | [useToggle](/es/hooks/useToggle)                         | Un estado booleano y una función para alternarlo                           |
+| Esperar a que termine la escritura       | [useDebouncedValue](/es/hooks/useDebouncedValue)         | Una copia del estado con retraso; el campo sigue respondiendo de inmediato |
+| Retrasar un callback                     | [useDebounce](/es/hooks/useDebounce)                     | Una función invocable con el método `.cancel()`                            |
+| Limitar la frecuencia de un callback     | [useThrottledCallback](/es/hooks/useThrottledCallback)   | Un callback con frecuencia limitada al intervalo configurado               |
+| Conservar el estado al recargar          | [useStorageState](/es/hooks/useStorageState)             | Estado persistido en el almacenamiento del navegador                       |
+| Responder a un clic fuera de un elemento | [useOutsideClickEffect](/es/hooks/useOutsideClickEffect) | Una suscripción a clics externos                                           |
+| Mantener un campo sobre el teclado       | [useAvoidKeyboard](/es/hooks/useAvoidKeyboard)           | Un estilo para posicionar un elemento fijo                                 |
+| Insertar separadores entre hijos         | [Separated](/es/components/Separated)                    | Separadores sin uno al final                                               |
+| Conectar varias refs a un elemento       | [mergeRefs](/es/utils/mergeRefs)                         | Un único callback de ref que reenvía a cada ref                            |
+
+## Mostrar y ocultar detalles
+
+Renderiza `<Details />` en tu aplicación React. El botón alterna tanto el contenido como su estado expandido.
+
+```tsx
+import { useToggle } from 'react-simplikit';
+
+export function Details() {
+  const [open, toggle] = useToggle(false);
+
+  return (
+    <section>
+      <button type="button" aria-expanded={open} onClick={toggle}>
+        Details
+      </button>
+      {open && <p>Delivery takes 3–5 days.</p>}
+    </section>
+  );
+}
+```
+
+## Filtrar cuando termina la escritura
+
+Renderiza `<FruitSearch />` en tu aplicación React. Escribe `ap`: el campo se actualiza de inmediato y la lista muestra Apple tras 300 ms sin otro cambio. Este ejemplo usa datos locales y no necesita un servidor.
+
+```tsx
+import { useState } from 'react';
+import { useDebouncedValue } from 'react-simplikit';
+
+const fruits = ['Apple', 'Banana', 'Orange'];
+
+export function FruitSearch() {
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const results = fruits.filter(fruit =>
+    fruit.toLowerCase().includes(debouncedQuery.toLowerCase())
+  );
+
+  return (
+    <section>
+      <label>
+        Search fruit
+        <input value={query} onChange={event => setQuery(event.target.value)} />
+      </label>
+      <ul aria-live="polite">
+        {results.map(fruit => (
+          <li key={fruit}>{fruit}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+Usa [useDebouncedValue](/es/hooks/useDebouncedValue) cuando necesites un valor para renderizar. Usa [useDebounce](/es/hooks/useDebounce) cuando un evento deba programar un callback. Aplicar debounce no acelera por sí solo un cálculo costoso.
+
+## SSR y limpieza
+
+- Llama a los Hooks en el nivel superior de un componente React o de un Hook personalizado. Si tu framework usa Server Components, coloca estos ejemplos interactivos en un Client Component (`'use client'`).
+
+- `useDebouncedValue` devuelve el valor recibido en el servidor y en el primer renderizado. Proporciona el mismo valor inicial al servidor y al cliente; no leas `window` ni el almacenamiento durante el renderizado para construirlo.
+
+- `useStorageState` usa `defaultValue` para la instantánea del servidor y la hidratación, y luego lee el almacenamiento del navegador en el cliente. Al desmontarse, elimina los listeners de almacenamiento.
+
+- `useDebounce` cancela las llamadas pendientes cuando el componente se desmonta o cambia la instancia de debounce. No cancela una solicitud de red que ya haya comenzado; tu aplicación debe gestionar la cancelación o las respuestas obsoletas.
+
+- Las mediciones del navegador pueden cambiar después del montaje. Consulta los valores iniciales y las restricciones de plataforma en [Web móvil](/es/mobile-web) y en la referencia de cada API.
+
+## Siguientes pasos
+
+Consulta la [referencia completa de API](/es/reference) para encontrar otras herramientas, o configura la [integración con IA](/es/ai-integration) para que tu agente encuentre la misma documentación.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,3 +40,5 @@ import { useToggle } from 'react-simplikit';
 ```
 
 All hooks are tree-shakeable, so you only include what you use in your bundle.
+
+Continue with [common use cases](/use-cases) for complete examples, or browse the [API reference](/reference).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -121,3 +121,5 @@ Compared to react-use, which has [14 dependencies](https://www.npmjs.com/package
 For more information about react-simplikit, please check out the following link:
 
 - [GitHub](https://github.com/toss/react-simplikit)
+
+Continue with [common use cases](/use-cases) for complete examples, or browse the [API reference](/reference).

--- a/docs/ja/ai-integration.md
+++ b/docs/ja/ai-integration.md
@@ -1,0 +1,52 @@
+---
+description: AI コーディングエージェントと react-simplikit を使う
+---
+
+# AI 連携
+
+react-simplikit は、AI コーディングエージェント（Claude Code、Codex、Cursor など）がフックを自作する前に適切なフックを探せるよう、資料を提供しています。
+
+## エージェントスキル
+
+`react-simplikit` スキルは、すべてのフック、コンポーネント、ユーティリティの 1 行説明付きカタログと、import・SSR のルールを含みます。インストールすると、エージェントはデバウンス、スロットル、外側のクリック検知、キーボード回避などのロジックを書く前に参照でき、API を使う前に付属のリファレンスを読めます。
+
+::: code-group
+
+```sh [skills.sh]
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+```sh [Claude Code]
+claude plugin marketplace add https://github.com/toss/react-simplikit --sparse .claude-plugin packages/plugin
+claude plugin install react-simplikit@react-simplikit
+```
+
+```sh [Codex]
+codex plugin marketplace add https://github.com/toss/react-simplikit
+# then install "react-simplikit" from the plugin UI
+```
+
+:::
+
+スキルはこれらのドキュメントから生成され、ライブラリとの整合性を保ちます。ソースは [`packages/plugin`](https://github.com/toss/react-simplikit/tree/main/packages/plugin) にあります。
+
+## llms.txt
+
+ドキュメントはエージェントが直接読める形式でも公開されています。
+
+- [`/llms.txt`](https://react-simplikit.slash.page/llms.txt) — すべてのページの索引と 1 行の要約
+- [`/llms-full.txt`](https://react-simplikit.slash.page/llms-full.txt) — ドキュメント全体をまとめた 1 ファイル
+- ページの URL の末尾を `.md` にすると生の Markdown を取得できます。例： [`/hooks/useDebounce.md`](https://react-simplikit.slash.page/hooks/useDebounce.md)
+
+## Context7
+
+react-simplikit は [Context7](https://context7.com/toss/react-simplikit) に `/toss/react-simplikit` として登録されています。Context7 MCP サーバーを使うエージェントは、追加の設定なしでそこからドキュメントを検索できます。
+
+## エージェントのアクセスを確認する
+
+1. インストールしたスキルまたは [llms.txt](https://react-simplikit.slash.page/llms.txt) を使い、具体的な作業に合う API を探すようエージェントに依頼してください。たとえば、検索コールバックを 300 ms 遅らせる作業です。
+2. リンク先の [useDebounce の Markdown リファレンス](https://react-simplikit.slash.page/hooks/useDebounce.md) を読み、コードを書く前に import、パラメータ、デフォルト値、クリーンアップの動作を説明するよう依頼してください。
+3. `react-simplikit` の名前付き import を使い、コールバックの遅延と値の遅延を区別し、保留中のコールバックのキャンセルでは開始済みのリクエストが中止されないと説明することを確認してください。
+4. インストール済みのパッケージバージョンでその API が使えるかを確認し、プロジェクトでコードを実行してください。サイトは最新のドキュメントを提供しているため、正しい文書を見つけても古いバージョンとの互換性は保証されません。
+
+エージェントがスキルやサイトにアクセスできない場合は、必要な Markdown リファレンスを直接渡してください。インストールしただけでは、エージェントが文書を読んだことの確認にはなりません。生成されたスキルカタログには API 項目が載っています。必要な動作を説明する際は [用途別の使い方](/ja/use-cases) を参照してください。

--- a/docs/ja/installation.md
+++ b/docs/ja/installation.md
@@ -40,3 +40,5 @@ import { useToggle } from 'react-simplikit';
 ```
 
 すべてのフックはツリーシェイキング対応なので、実際に使用するものだけがバンドルに含まれます。
+
+完全な使用例は [用途別の使い方](/ja/use-cases)、ツールの一覧は [API リファレンス](/ja/reference) をご覧ください。

--- a/docs/ja/intro.md
+++ b/docs/ja/intro.md
@@ -121,3 +121,5 @@ React と React-DOM を除いて [14 個の依存関係](https://www.npmjs.com/p
 react-simplikit についてさらに詳しく知りたい方は、以下のリンクをご覧ください。
 
 - [GitHub](https://github.com/toss/react-simplikit)
+
+完全な使用例は [用途別の使い方](/ja/use-cases)、ツールの一覧は [API リファレンス](/ja/reference) をご覧ください。

--- a/docs/ja/use-cases.md
+++ b/docs/ja/use-cases.md
@@ -1,0 +1,93 @@
+---
+description: 解決したい問題に合う React ユーティリティを選ぶ
+---
+
+# 用途別の使い方
+
+必要な動作に合う API を選び、リファレンスでパラメータとエッジケースを確認してください。使用例を試す前に [react-simplikit をインストールしてください](/ja/installation)。
+
+## API を選ぶ
+
+| 問題                                 | API                                                      | 提供する機能                                         |
+| ------------------------------------ | -------------------------------------------------------- | ---------------------------------------------------- |
+| コンテンツを表示・非表示にする       | [useToggle](/ja/hooks/useToggle)                         | 真偽値の状態とトグル関数                             |
+| 入力が止まるまで待つ                 | [useDebouncedValue](/ja/hooks/useDebouncedValue)         | 入力の即時反映を保ちながら、状態のコピーを遅れて更新 |
+| コールバックの呼び出しを遅らせる     | [useDebounce](/ja/hooks/useDebounce)                     | `.cancel()` メソッドを持つ呼び出し可能な関数         |
+| コールバックの呼び出し頻度を制限する | [useThrottledCallback](/ja/hooks/useThrottledCallback)   | 指定した間隔で呼び出し頻度を制限するコールバック     |
+| 再読み込み後も状態を保持する         | [useStorageState](/ja/hooks/useStorageState)             | ブラウザストレージに保存される状態                   |
+| 要素の外側のクリックに反応する       | [useOutsideClickEffect](/ja/hooks/useOutsideClickEffect) | 外側のクリックの購読                                 |
+| 入力欄をキーボードの上に保つ         | [useAvoidKeyboard](/ja/hooks/useAvoidKeyboard)           | 固定要素の位置を調整するスタイル                     |
+| 子要素の間に区切りを入れる           | [Separated](/ja/components/Separated)                    | 末尾には付かない区切り                               |
+| 1 つの要素に複数の ref を接続する    | [mergeRefs](/ja/utils/mergeRefs)                         | 各 ref に転送する 1 つの ref コールバック            |
+
+## 詳細を表示・非表示にする
+
+React アプリで `<Details />` をレンダリングしてください。ボタンを押すと、コンテンツの表示と展開状態が切り替わります。
+
+```tsx
+import { useToggle } from 'react-simplikit';
+
+export function Details() {
+  const [open, toggle] = useToggle(false);
+
+  return (
+    <section>
+      <button type="button" aria-expanded={open} onClick={toggle}>
+        Details
+      </button>
+      {open && <p>Delivery takes 3–5 days.</p>}
+    </section>
+  );
+}
+```
+
+## 入力が止まってから絞り込む
+
+React アプリで `<FruitSearch />` をレンダリングしてください。`ap` と入力すると入力欄はすぐに更新され、その後 300 ms 入力がなければリストに Apple が表示されます。ローカルデータを使うのでサーバーは不要です。
+
+```tsx
+import { useState } from 'react';
+import { useDebouncedValue } from 'react-simplikit';
+
+const fruits = ['Apple', 'Banana', 'Orange'];
+
+export function FruitSearch() {
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const results = fruits.filter(fruit =>
+    fruit.toLowerCase().includes(debouncedQuery.toLowerCase())
+  );
+
+  return (
+    <section>
+      <label>
+        Search fruit
+        <input value={query} onChange={event => setQuery(event.target.value)} />
+      </label>
+      <ul aria-live="polite">
+        {results.map(fruit => (
+          <li key={fruit}>{fruit}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+レンダリングに使う値が必要なら [useDebouncedValue](/ja/hooks/useDebouncedValue) を使ってください。イベントからコールバックを予約するなら [useDebounce](/ja/hooks/useDebounce) を使ってください。デバウンス自体が重い計算を速くするわけではありません。
+
+## SSR とクリーンアップ
+
+- フックは React コンポーネントまたはカスタムフックのトップレベルで呼び出してください。Server Components を使うフレームワークでは、これらの対話的な使用例を Client Component（`'use client'`）に配置してください。
+
+- `useDebouncedValue` はサーバーと初回レンダリングで渡された値をそのまま返します。サーバーとクライアントには同じ初期値を渡し、その値を作るためにレンダリング中に `window` やストレージを読み取らないでください。
+
+- `useStorageState` はサーバースナップショットと hydration に `defaultValue` を使い、その後クライアントでブラウザストレージを読み取ります。アンマウント時にストレージのリスナーを解除します。
+
+- `useDebounce` はアンマウント時やデバウンスのインスタンスが変わったときに保留中の呼び出しをキャンセルします。開始済みのネットワークリクエストはキャンセルしないため、リクエストの中止や古いレスポンスの処理はアプリケーション側で行う必要があります。
+
+- ブラウザの測定値はマウント後に変わることがあります。初期値とプラットフォームの制約は [モバイル Web](/ja/mobile-web) と各 API のリファレンスで確認してください。
+
+## 次のステップ
+
+他のツールは [API リファレンス一覧](/ja/reference) で探せます。エージェントが同じドキュメントを見つけられるように [AI 連携](/ja/ai-integration) を設定することもできます。

--- a/docs/ko/ai-integration.md
+++ b/docs/ko/ai-integration.md
@@ -41,3 +41,12 @@ codex plugin marketplace add https://github.com/toss/react-simplikit
 ## Context7
 
 react-simplikit은 [Context7](https://context7.com/toss/react-simplikit)에 `/toss/react-simplikit`으로 등록되어 있어요. Context7 MCP 서버를 쓰는 에이전트는 별도 설정 없이 문서를 조회할 수 있어요.
+
+## 에이전트 접근 확인하기
+
+1. 설치한 스킬이나 [llms.txt](https://react-simplikit.slash.page/llms.txt)를 사용해 구체적인 작업에 맞는 API를 찾도록 요청하세요. 예를 들어 검색 콜백을 300ms 늦추는 작업을 요청할 수 있어요.
+2. 연결된 [useDebounce Markdown 레퍼런스](https://react-simplikit.slash.page/hooks/useDebounce.md)를 읽고, 코드를 쓰기 전에 import, 파라미터, 기본값과 정리 동작을 설명하도록 요청하세요.
+3. `react-simplikit`의 named import를 사용하는지, 콜백을 늦추는 것과 값을 늦추는 것을 구분하는지, 대기 중인 콜백 취소가 이미 시작한 요청을 중단하지 않는다고 설명하는지 확인하세요.
+4. 설치한 패키지 버전에서 해당 API를 제공하는지 확인하고 프로젝트에서 코드를 실행하세요. 웹사이트는 최신 문서를 제공하므로, 문서를 정확하게 찾았더라도 이전 설치 버전과 호환된다고 보장할 수는 없어요.
+
+에이전트가 스킬을 불러오거나 사이트에 접근하지 못하면 필요한 Markdown 레퍼런스를 직접 제공하세요. 설치만으로 에이전트가 문서를 읽었다고 확인할 수는 없어요. 생성된 스킬 카탈로그에는 API 항목이 있어요. 필요한 동작을 설명할 때는 [문제별 사용법](/ko/use-cases)을 참고하세요.

--- a/docs/ko/installation.md
+++ b/docs/ko/installation.md
@@ -40,3 +40,5 @@ import { useToggle } from 'react-simplikit';
 ```
 
 모든 훅은 트리 쉐이킹이 가능하므로, 번들에는 사용하는 것만 포함돼요.
+
+완전한 예제는 [문제별 사용법](/ko/use-cases)에서 확인하고, 전체 도구는 [API 레퍼런스](/ko/reference)에서 찾아보세요.

--- a/docs/ko/intro.md
+++ b/docs/ko/intro.md
@@ -52,3 +52,5 @@ SSR 환경의 활발한 도입으로, 잘못 작성된 컴포넌트나 훅이 SS
 react-simplikit에 대한 더 많은 정보는 다음 링크를 확인해 주세요:
 
 - [GitHub](https://github.com/toss/react-simplikit)
+
+완전한 예제는 [문제별 사용법](/ko/use-cases)에서 확인하고, 전체 도구는 [API 레퍼런스](/ko/reference)에서 찾아보세요.

--- a/docs/ko/use-cases.md
+++ b/docs/ko/use-cases.md
@@ -1,0 +1,93 @@
+---
+description: 해결하려는 문제에 맞는 React 유틸리티 선택하기
+---
+
+# 문제별 사용법
+
+필요한 동작에 맞는 API를 고른 뒤, 레퍼런스에서 파라미터와 예외 상황을 확인하세요. 예제를 실행하기 전에 [react-simplikit을 설치하세요](/ko/installation).
+
+## API 선택하기
+
+| 문제                          | API                                                      | 제공하는 기능                                      |
+| ----------------------------- | -------------------------------------------------------- | -------------------------------------------------- |
+| 콘텐츠를 보이거나 숨기기      | [useToggle](/ko/hooks/useToggle)                         | 불리언 상태와 토글 함수                            |
+| 입력이 멈출 때까지 기다리기   | [useDebouncedValue](/ko/hooks/useDebouncedValue)         | 입력은 즉시 반영하면서 상태의 사본을 늦게 갱신해요 |
+| 콜백 호출을 늦추기            | [useDebounce](/ko/hooks/useDebounce)                     | `.cancel()` 메서드가 있는 호출 가능한 함수         |
+| 콜백 호출 빈도 제한하기       | [useThrottledCallback](/ko/hooks/useThrottledCallback)   | 설정한 간격으로 호출 빈도를 제한하는 콜백          |
+| 새로고침 후에도 상태 유지하기 | [useStorageState](/ko/hooks/useStorageState)             | 브라우저 저장소에 유지되는 상태                    |
+| 요소 바깥 클릭에 반응하기     | [useOutsideClickEffect](/ko/hooks/useOutsideClickEffect) | 요소 바깥 클릭 구독                                |
+| 입력창을 키보드 위에 유지하기 | [useAvoidKeyboard](/ko/hooks/useAvoidKeyboard)           | 고정 요소의 위치를 조절하는 스타일                 |
+| 자식 요소 사이에 구분자 넣기  | [Separated](/ko/components/Separated)                    | 마지막 요소 뒤에는 붙지 않는 구분자                |
+| 한 요소에 여러 ref 연결하기   | [mergeRefs](/ko/utils/mergeRefs)                         | 각 ref로 전달하는 하나의 ref 콜백                  |
+
+## 상세 내용 보이거나 숨기기
+
+React 앱에서 `<Details />`를 렌더링하세요. 버튼을 누르면 콘텐츠 표시 여부와 펼침 상태가 함께 바뀌어요.
+
+```tsx
+import { useToggle } from 'react-simplikit';
+
+export function Details() {
+  const [open, toggle] = useToggle(false);
+
+  return (
+    <section>
+      <button type="button" aria-expanded={open} onClick={toggle}>
+        Details
+      </button>
+      {open && <p>Delivery takes 3–5 days.</p>}
+    </section>
+  );
+}
+```
+
+## 입력이 멈춘 뒤 필터링하기
+
+React 앱에서 `<FruitSearch />`를 렌더링하세요. `ap`를 입력하면 입력창은 즉시 갱신되고, 추가 입력 없이 300ms가 지나면 목록에 Apple이 표시돼요. 로컬 데이터를 사용하므로 서버가 필요하지 않아요.
+
+```tsx
+import { useState } from 'react';
+import { useDebouncedValue } from 'react-simplikit';
+
+const fruits = ['Apple', 'Banana', 'Orange'];
+
+export function FruitSearch() {
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const results = fruits.filter(fruit =>
+    fruit.toLowerCase().includes(debouncedQuery.toLowerCase())
+  );
+
+  return (
+    <section>
+      <label>
+        Search fruit
+        <input value={query} onChange={event => setQuery(event.target.value)} />
+      </label>
+      <ul aria-live="polite">
+        {results.map(fruit => (
+          <li key={fruit}>{fruit}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+렌더링에 사용할 값이 필요하면 [useDebouncedValue](/ko/hooks/useDebouncedValue)를 사용하세요. 이벤트에서 콜백 실행을 예약하려면 [useDebounce](/ko/hooks/useDebounce)를 사용하세요. 디바운스 자체가 무거운 계산을 빠르게 만들지는 않아요.
+
+## SSR과 정리 동작
+
+- 훅은 React 컴포넌트나 커스텀 훅의 최상위에서 호출하세요. 서버 컴포넌트를 사용하는 프레임워크에서는 상호작용이 있는 이 예제를 클라이언트 컴포넌트(`'use client'`)에 넣으세요.
+
+- `useDebouncedValue`는 서버와 첫 렌더에서 전달받은 값을 그대로 반환해요. 서버와 클라이언트에 같은 초기값을 전달하고, 그 값을 만들기 위해 렌더 도중 `window`나 저장소를 읽지 마세요.
+
+- `useStorageState`는 서버 스냅샷과 hydration에 `defaultValue`를 사용한 뒤 클라이언트에서 브라우저 저장소를 읽어요. 언마운트 시 저장소 리스너를 제거해요.
+
+- `useDebounce`는 컴포넌트가 언마운트되거나 디바운스 인스턴스가 바뀌면 대기 중인 호출을 취소해요. 이미 시작한 네트워크 요청은 취소하지 않으므로, 요청 취소나 오래된 응답 처리는 애플리케이션에서 담당해야 해요.
+
+- 브라우저 측정값은 마운트 후에 바뀔 수 있어요. 초기값과 플랫폼 제약은 [모바일 웹](/ko/mobile-web) 가이드와 개별 API 레퍼런스에서 확인하세요.
+
+## 다음 단계
+
+다른 도구는 [전체 API 레퍼런스](/ko/reference)에서 찾을 수 있어요. 에이전트도 같은 문서를 찾도록 [AI 연동](/ko/ai-integration)을 설정할 수 있어요.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,93 @@
+---
+description: Choose a React utility by the problem you need to solve
+---
+
+# Common use cases
+
+Start with the behavior you need, then open the API reference for its parameters and edge cases. [Install react-simplikit](/installation) before trying the examples.
+
+## Choose an API
+
+| Problem                             | API                                                   | What it provides                                           |
+| ----------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------- |
+| Show or hide content                | [useToggle](/hooks/useToggle)                         | A boolean and a toggle function                            |
+| Wait for typing to pause            | [useDebouncedValue](/hooks/useDebouncedValue)         | A delayed copy of state; the input itself stays responsive |
+| Delay a callback                    | [useDebounce](/hooks/useDebounce)                     | A callable function with a `.cancel()` method              |
+| Limit callback frequency            | [useThrottledCallback](/hooks/useThrottledCallback)   | A callback limited to the configured interval              |
+| Keep state across reloads           | [useStorageState](/hooks/useStorageState)             | State persisted in browser storage                         |
+| React to a click outside an element | [useOutsideClickEffect](/hooks/useOutsideClickEffect) | An outside-click subscription                              |
+| Keep an input above the keyboard    | [useAvoidKeyboard](/hooks/useAvoidKeyboard)           | A style for positioning a fixed element                    |
+| Insert separators between children  | [Separated](/components/Separated)                    | Separators without a trailing separator                    |
+| Attach multiple refs to one element | [mergeRefs](/utils/mergeRefs)                         | One ref callback that forwards to each ref                 |
+
+## Show and hide details
+
+Render `<Details />` in your React app. The button toggles both the content and its expanded state.
+
+```tsx
+import { useToggle } from 'react-simplikit';
+
+export function Details() {
+  const [open, toggle] = useToggle(false);
+
+  return (
+    <section>
+      <button type="button" aria-expanded={open} onClick={toggle}>
+        Details
+      </button>
+      {open && <p>Delivery takes 3–5 days.</p>}
+    </section>
+  );
+}
+```
+
+## Filter after typing pauses
+
+Render `<FruitSearch />` in your React app. Type `ap`: the input updates immediately, and the list shows Apple after 300 ms without another change. This example uses local data and needs no server.
+
+```tsx
+import { useState } from 'react';
+import { useDebouncedValue } from 'react-simplikit';
+
+const fruits = ['Apple', 'Banana', 'Orange'];
+
+export function FruitSearch() {
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const results = fruits.filter(fruit =>
+    fruit.toLowerCase().includes(debouncedQuery.toLowerCase())
+  );
+
+  return (
+    <section>
+      <label>
+        Search fruit
+        <input value={query} onChange={event => setQuery(event.target.value)} />
+      </label>
+      <ul aria-live="polite">
+        {results.map(fruit => (
+          <li key={fruit}>{fruit}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+Use [useDebouncedValue](/hooks/useDebouncedValue) when you need a value for rendering. Use [useDebounce](/hooks/useDebounce) when an event should schedule a callback. Debouncing alone does not make an expensive calculation faster.
+
+## SSR and cleanup
+
+- Call hooks at the top level of a React component or custom hook. In a framework with Server Components, put these interactive examples in a Client Component (`'use client'`).
+
+- `useDebouncedValue` returns the supplied value on the server and the first render. Give the server and client the same initial value; do not read `window` or storage during render to construct it.
+
+- `useStorageState` uses `defaultValue` for the server snapshot and hydration, then reads browser storage on the client. Its storage listeners are removed on unmount.
+
+- `useDebounce` cancels pending calls when the component unmounts or the debounce instance changes. It does not cancel a network request that has already started; the application must handle request cancellation or stale responses.
+
+- Browser measurements can change after mount. Check the initial values and platform constraints in [Mobile Web](/mobile-web) and the individual API reference.
+
+## Next steps
+
+Browse the [full API reference](/reference) for other tools, or set up [AI Integration](/ai-integration) so your agent can find the same documentation.

--- a/docs/zh-Hans/ai-integration.md
+++ b/docs/zh-Hans/ai-integration.md
@@ -1,0 +1,52 @@
+---
+description: 通过 AI 编程 agent 使用 react-simplikit
+---
+
+# AI 集成
+
+react-simplikit 提供了多种资料，帮助 AI 编程 agent（Claude Code、Codex、Cursor 等）在手写 Hook 之前找到合适的现有 Hook。
+
+## Agent skill
+
+`react-simplikit` skill 包含所有 Hook、组件和工具函数的目录及一句话说明，以及 import 和 SSR 规则。安装后，agent 可以在编写防抖、节流、外部点击检测、键盘避让等逻辑前查阅目录，并在使用 API 前阅读附带的参考文档。
+
+::: code-group
+
+```sh [skills.sh]
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+```sh [Claude Code]
+claude plugin marketplace add https://github.com/toss/react-simplikit --sparse .claude-plugin packages/plugin
+claude plugin install react-simplikit@react-simplikit
+```
+
+```sh [Codex]
+codex plugin marketplace add https://github.com/toss/react-simplikit
+# then install "react-simplikit" from the plugin UI
+```
+
+:::
+
+Skill 由这些文档页面生成，以保持与库的内容一致。源代码位于 [`packages/plugin`](https://github.com/toss/react-simplikit/tree/main/packages/plugin)。
+
+## llms.txt
+
+文档也以 agent 可以直接读取的格式发布。
+
+- [`/llms.txt`](https://react-simplikit.slash.page/llms.txt) — 所有页面的索引和一句话摘要
+- [`/llms-full.txt`](https://react-simplikit.slash.page/llms-full.txt) — 合并为单个文件的完整文档
+- 将页面 URL 的后缀改为 `.md` 即可获取原始 Markdown，例如： [`/hooks/useDebounce.md`](https://react-simplikit.slash.page/hooks/useDebounce.md)
+
+## Context7
+
+react-simplikit 已在 [Context7](https://context7.com/toss/react-simplikit) 中以 `/toss/react-simplikit` 收录。使用 Context7 MCP 服务器的 agent 无需额外配置即可查询文档。
+
+## 验证 agent 访问
+
+1. 让 agent 使用已安装的 skill 或 [llms.txt](https://react-simplikit.slash.page/llms.txt)，为具体任务查找 API，例如将搜索回调延迟 300 ms。
+2. 让它读取链接中的 [useDebounce Markdown 参考](https://react-simplikit.slash.page/hooks/useDebounce.md)，并在编写代码前说明 import、参数、默认值和清理行为。
+3. 确认它从 `react-simplikit` 使用具名导入，能够区分延迟回调与延迟值，并说明取消待执行回调不会中止已经开始的请求。
+4. 检查已安装的包版本是否提供该 API，并在项目中运行代码。网站提供最新文档；查找正确并不代表与旧版本兼容。
+
+如果 agent 无法加载 skill 或访问网站，请直接提供相关 Markdown 参考。仅安装 skill 不能证明 agent 已读取文档。生成的 skill 目录列出了 API 条目；描述所需行为时，可以参考[常见使用场景](/zh-Hans/use-cases)。

--- a/docs/zh-Hans/installation.md
+++ b/docs/zh-Hans/installation.md
@@ -40,3 +40,5 @@ import { useToggle } from 'react-simplikit';
 ```
 
 所有 Hook 都支持 tree shaking，因此只有你真正用到的部分才会被打进包里。
+
+在[常见使用场景](/zh-Hans/use-cases) 中查看完整示例，或浏览 [API 参考](/zh-Hans/reference)。

--- a/docs/zh-Hans/intro.md
+++ b/docs/zh-Hans/intro.md
@@ -121,3 +121,5 @@ react-use 在 React 和 React-DOM 之外还有 [14 个依赖](https://www.npmjs.
 想进一步了解 react-simplikit，请查看下面的链接：
 
 - [GitHub](https://github.com/toss/react-simplikit)
+
+在[常见使用场景](/zh-Hans/use-cases) 中查看完整示例，或浏览 [API 参考](/zh-Hans/reference)。

--- a/docs/zh-Hans/use-cases.md
+++ b/docs/zh-Hans/use-cases.md
@@ -1,0 +1,93 @@
+---
+description: 根据要解决的问题选择 React 工具函数
+---
+
+# 常见使用场景
+
+先根据所需行为选择 API，再查阅参考文档中的参数和边界情况。尝试示例前，请先[安装 react-simplikit](/zh-Hans/installation)。
+
+## 选择 API
+
+| 问题                   | API                                                           | 提供的功能                             |
+| ---------------------- | ------------------------------------------------------------- | -------------------------------------- |
+| 显示或隐藏内容         | [useToggle](/zh-Hans/hooks/useToggle)                         | 布尔状态和切换函数                     |
+| 等待用户停止输入       | [useDebouncedValue](/zh-Hans/hooks/useDebouncedValue)         | 延迟更新的状态副本，输入框仍然即时响应 |
+| 延迟调用回调           | [useDebounce](/zh-Hans/hooks/useDebounce)                     | 带有 `.cancel()` 方法的可调用函数      |
+| 限制回调频率           | [useThrottledCallback](/zh-Hans/hooks/useThrottledCallback)   | 按设定间隔限制调用频率的回调           |
+| 刷新后保留状态         | [useStorageState](/zh-Hans/hooks/useStorageState)             | 保存在浏览器存储中的状态               |
+| 响应元素外部的点击     | [useOutsideClickEffect](/zh-Hans/hooks/useOutsideClickEffect) | 元素外部点击订阅                       |
+| 让输入框保持在键盘上方 | [useAvoidKeyboard](/zh-Hans/hooks/useAvoidKeyboard)           | 用于定位固定元素的样式                 |
+| 在子元素之间插入分隔符 | [Separated](/zh-Hans/components/Separated)                    | 末尾没有分隔符                         |
+| 为一个元素连接多个 ref | [mergeRefs](/zh-Hans/utils/mergeRefs)                         | 向各个 ref 转发的单个 ref 回调         |
+
+## 显示和隐藏详情
+
+在 React 应用中渲染 `<Details />`。点击按钮会同时切换内容显示和展开状态。
+
+```tsx
+import { useToggle } from 'react-simplikit';
+
+export function Details() {
+  const [open, toggle] = useToggle(false);
+
+  return (
+    <section>
+      <button type="button" aria-expanded={open} onClick={toggle}>
+        Details
+      </button>
+      {open && <p>Delivery takes 3–5 days.</p>}
+    </section>
+  );
+}
+```
+
+## 停止输入后筛选
+
+在 React 应用中渲染 `<FruitSearch />`。输入 `ap` 后，输入框立即更新；如果 300 ms 内没有再次输入，列表就会显示 Apple。此示例使用本地数据，无需服务器。
+
+```tsx
+import { useState } from 'react';
+import { useDebouncedValue } from 'react-simplikit';
+
+const fruits = ['Apple', 'Banana', 'Orange'];
+
+export function FruitSearch() {
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const results = fruits.filter(fruit =>
+    fruit.toLowerCase().includes(debouncedQuery.toLowerCase())
+  );
+
+  return (
+    <section>
+      <label>
+        Search fruit
+        <input value={query} onChange={event => setQuery(event.target.value)} />
+      </label>
+      <ul aria-live="polite">
+        {results.map(fruit => (
+          <li key={fruit}>{fruit}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+需要用于渲染的值时，使用 [useDebouncedValue](/zh-Hans/hooks/useDebouncedValue)。需要通过事件安排回调时，使用 [useDebounce](/zh-Hans/hooks/useDebounce)。防抖本身不会加快耗时计算。
+
+## SSR 与清理
+
+- 在 React 组件或自定义 Hook 的顶层调用 Hook。如果框架使用 Server Components，请将这些交互式示例放在 Client Component（`'use client'`）中。
+
+- `useDebouncedValue` 在服务端和首次渲染时原样返回传入的值。为服务端和客户端提供相同的初始值，不要在渲染过程中读取 `window` 或存储来构造该值。
+
+- `useStorageState` 使用 `defaultValue` 作为服务端快照和 hydration 的值，随后在客户端读取浏览器存储。卸载时会移除存储监听器。
+
+- `useDebounce` 在组件卸载或防抖实例变化时取消待执行的调用，但不会取消已经开始的网络请求。应用需要处理请求取消或过期响应。
+
+- 浏览器测量值可能在挂载后发生变化。请在[移动 Web](/zh-Hans/mobile-web) 指南和各 API 参考文档中查看初始值及平台限制。
+
+## 后续步骤
+
+在[完整 API 参考](/zh-Hans/reference) 中查找其他工具，或设置 [AI 集成](/zh-Hans/ai-integration)，让 agent 查阅同样的文档。

--- a/packages/plugin/skills/react-simplikit/references/useDebounce.md
+++ b/packages/plugin/skills/react-simplikit/references/useDebounce.md
@@ -2,6 +2,8 @@
 
 `useDebounce` is a React hook that returns a debounced version of the provided callback function. It helps optimize event handling by delaying function execution and grouping multiple calls into one.
 
+With the default options, the last call runs after `wait` milliseconds without another call. Pending calls are cancelled on unmount or when the debounce instance changes. Calling `.cancel()` only cancels a pending callback, not an already-started network request. The example displays the submitted query locally; replace `setSubmittedQuery` with your application's search callback when connecting a server.
+
 ## Interface
 
 ```ts
@@ -63,23 +65,31 @@ function useDebounce<F extends (...args: any[]) => unknown>(
 ## Example
 
 ```tsx
-function SearchInput() {
-  const [query, setQuery] = useState('');
+import { useState } from 'react';
+import { useDebounce } from 'react-simplikit';
 
-  const debouncedSearch = useDebounce((value: string) => {
-    // Actual API call
-    searchAPI(value);
-  }, 300);
+export function SearchInput() {
+  const [query, setQuery] = useState('');
+  const [submittedQuery, setSubmittedQuery] = useState('');
+  const debouncedSearch = useDebounce(setSubmittedQuery, 300);
 
   return (
-    <input
-      value={query}
-      onChange={e => {
-        setQuery(e.target.value);
-        debouncedSearch(e.target.value);
-      }}
-      placeholder="Enter search term"
-    />
+    <section>
+      <label>
+        Search
+        <input
+          value={query}
+          onChange={event => {
+            setQuery(event.target.value);
+            debouncedSearch(event.target.value);
+          }}
+        />
+      </label>
+      <output aria-live="polite">{submittedQuery}</output>
+      <button type="button" onClick={() => debouncedSearch.cancel()}>
+        Cancel pending update
+      </button>
+    </section>
   );
 }
 ```

--- a/packages/plugin/skills/react-simplikit/references/useDebouncedValue.md
+++ b/packages/plugin/skills/react-simplikit/references/useDebouncedValue.md
@@ -2,6 +2,8 @@
 
 `useDebouncedValue` is a React hook that returns a debounced copy of the given value. The caller keeps owning the state; the hook only delays how quickly the returned value follows it. The returned value updates `wait` milliseconds after the last change, which is useful for deriving a search query or a validation input from fast-changing state.
 
+Pending updates are cancelled when the component unmounts. The example displays the delayed query without requiring a search service or an additional component.
+
 On the first render and on the server the value is returned as is. A change is never scheduled on mount, so with `leading: true` the first change after mount is applied immediately. If both `leading` and `trailing` are `false`, the returned value never updates.
 
 The value is compared by reference. Passing a new object or array on every render keeps the returned value updating every `wait` milliseconds; stabilize the reference first, for example with `usePreservedReference`.
@@ -72,8 +74,11 @@ function SearchInput() {
 
   return (
     <>
-      <input value={query} onChange={e => setQuery(e.target.value)} />
-      <SearchResults query={debouncedQuery} />
+      <label>
+        Search
+        <input value={query} onChange={e => setQuery(e.target.value)} />
+      </label>
+      <output aria-live="polite">{debouncedQuery}</output>
     </>
   );
 }

--- a/packages/react-simplikit/README-es.md
+++ b/packages/react-simplikit/README-es.md
@@ -28,6 +28,8 @@ pnpm add react-simplikit
 
 ## Inicio rápido
 
+Usa `useDebounce` para llamar a tu función de búsqueda cuando el usuario deje de escribir durante 300 ms. En este ejemplo, `searchAPI` es la función de búsqueda que proporciona tu aplicación.
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -62,6 +64,16 @@ La función con debounce expone `.cancel()`, y las llamadas pendientes se cancel
 - **Utilidades** — `buildContext`, `mergeProps`, `mergeRefs` y funciones auxiliares para la web móvil como `isIOS` y `getKeyboardHeight`
 
 La lista completa, con una descripción de una línea por entrada, está en la [página de referencia](https://react-simplikit.slash.page/es/reference.html).
+
+## Integración con IA
+
+Ayuda a tu asistente de programación con IA a encontrar Hooks, componentes y utilidades existentes, y a consultar las reglas de importación y SSR con la skill de agente incluida.
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+Consulta la [guía de integración con IA (en inglés)](https://react-simplikit.slash.page/ai-integration.html) para conocer los detalles de configuración. Los agentes también pueden usar [llms.txt](https://react-simplikit.slash.page/llms.txt) para encontrar documentación de las API.
 
 ## Documentación
 

--- a/packages/react-simplikit/README-es.md
+++ b/packages/react-simplikit/README-es.md
@@ -73,9 +73,11 @@ Ayuda a tu asistente de programación con IA a encontrar Hooks, componentes y ut
 npx skills add toss/react-simplikit --skill react-simplikit
 ```
 
-Consulta la [guía de integración con IA (en inglés)](https://react-simplikit.slash.page/ai-integration.html) para conocer los detalles de configuración. Los agentes también pueden usar [llms.txt](https://react-simplikit.slash.page/llms.txt) para encontrar documentación de las API.
+Consulta la [guía de integración con IA](https://react-simplikit.slash.page/es/ai-integration.html) para conocer los detalles de configuración. Los agentes también pueden usar [llms.txt](https://react-simplikit.slash.page/llms.txt) para encontrar documentación de las API.
 
 ## Documentación
+
+Elige un Hook según el problema que necesitas resolver en [Casos de uso comunes](https://react-simplikit.slash.page/es/use-cases.html).
 
 Consulta la documentación completa en [react-simplikit.slash.page](https://react-simplikit.slash.page/es).
 

--- a/packages/react-simplikit/README-ja_jp.md
+++ b/packages/react-simplikit/README-ja_jp.md
@@ -73,9 +73,11 @@ function SearchInput() {
 npx skills add toss/react-simplikit --skill react-simplikit
 ```
 
-設定方法は [AI 連携ガイド（英語）](https://react-simplikit.slash.page/ai-integration.html)をご覧ください。エージェントは [llms.txt](https://react-simplikit.slash.page/llms.txt) からも API ドキュメントを探せます。
+設定方法は [AI 連携ガイド](https://react-simplikit.slash.page/ja/ai-integration.html)をご覧ください。エージェントは [llms.txt](https://react-simplikit.slash.page/llms.txt) からも API ドキュメントを探せます。
 
 ## ドキュメント
+
+解決したい問題に合うフックは [用途別の使い方](https://react-simplikit.slash.page/ja/use-cases.html) で探せます。
 
 詳しいドキュメントは [react-simplikit.slash.page](https://react-simplikit.slash.page/ja) をご覧ください。
 

--- a/packages/react-simplikit/README-ja_jp.md
+++ b/packages/react-simplikit/README-ja_jp.md
@@ -28,6 +28,8 @@ pnpm add react-simplikit
 
 ## クイックスタート
 
+`useDebounce` を使うと、ユーザーが入力を止めてから 300 ms 後に検索関数を呼び出せます。この例の `searchAPI` は、アプリケーション側で用意する検索関数です。
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -62,6 +64,16 @@ function SearchInput() {
 - **ユーティリティ** — `buildContext`、`mergeProps`、`mergeRefs`、および `isIOS` や `getKeyboardHeight` のようなモバイル Web 向けヘルパー
 
 1 行の説明付きの全リストは[リファレンスページ](https://react-simplikit.slash.page/ja/reference.html)にあります。
+
+## AI 連携
+
+付属のエージェントスキルを使うと、AI コーディングアシスタントが既存のフック、コンポーネント、ユーティリティを探し、import と SSR のルールを確認するのに役立ちます。
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+設定方法は [AI 連携ガイド（英語）](https://react-simplikit.slash.page/ai-integration.html)をご覧ください。エージェントは [llms.txt](https://react-simplikit.slash.page/llms.txt) からも API ドキュメントを探せます。
 
 ## ドキュメント
 

--- a/packages/react-simplikit/README-ko_kr.md
+++ b/packages/react-simplikit/README-ko_kr.md
@@ -77,6 +77,8 @@ npx skills add toss/react-simplikit --skill react-simplikit
 
 ## 문서
 
+해결하려는 문제에 맞는 훅은 [문제별 사용법](https://react-simplikit.slash.page/ko/use-cases.html)에서 찾아보세요.
+
 자세한 문서는 [react-simplikit.slash.page](https://react-simplikit.slash.page/ko)를 참고하세요.
 
 ## 기여하기

--- a/packages/react-simplikit/README-ko_kr.md
+++ b/packages/react-simplikit/README-ko_kr.md
@@ -28,6 +28,8 @@ pnpm add react-simplikit
 
 ## 빠른 시작
 
+`useDebounce`를 사용하면 사용자가 입력을 멈춘 뒤 300ms 후에 검색 함수를 호출할 수 있어요. 아래 예제의 `searchAPI`는 애플리케이션에서 제공하는 검색 함수예요.
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -62,6 +64,16 @@ function SearchInput() {
 - **유틸리티** — `buildContext`, `mergeProps`, `mergeRefs`, 그리고 `isIOS`, `getKeyboardHeight` 같은 모바일 웹 헬퍼
 
 한 줄 설명이 붙은 전체 목록은 [레퍼런스 페이지](https://react-simplikit.slash.page/ko/reference.html)에 있어요.
+
+## AI 연동
+
+함께 제공하는 에이전트 스킬로 AI 코딩 어시스턴트가 기존 훅·컴포넌트·유틸리티를 찾고, import와 SSR 규칙을 확인하도록 도와주세요.
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+설정 방법은 [AI 연동 가이드](https://react-simplikit.slash.page/ko/ai-integration.html)를 참고하세요. 에이전트는 [llms.txt](https://react-simplikit.slash.page/llms.txt)에서도 API 문서를 찾을 수 있어요.
 
 ## 문서
 

--- a/packages/react-simplikit/README-zh_hans.md
+++ b/packages/react-simplikit/README-zh_hans.md
@@ -73,9 +73,11 @@ function SearchInput() {
 npx skills add toss/react-simplikit --skill react-simplikit
 ```
 
-设置方法请参阅 [AI 集成指南（英文）](https://react-simplikit.slash.page/ai-integration.html)。Agent 也可以通过 [llms.txt](https://react-simplikit.slash.page/llms.txt) 查找 API 文档。
+设置方法请参阅 [AI 集成指南](https://react-simplikit.slash.page/zh-Hans/ai-integration.html)。Agent 也可以通过 [llms.txt](https://react-simplikit.slash.page/llms.txt) 查找 API 文档。
 
 ## 文档
+
+在[常见使用场景](https://react-simplikit.slash.page/zh-Hans/use-cases.html) 中，根据要解决的问题选择 Hook。
 
 完整文档请访问 [react-simplikit.slash.page](https://react-simplikit.slash.page/zh-Hans)。
 

--- a/packages/react-simplikit/README-zh_hans.md
+++ b/packages/react-simplikit/README-zh_hans.md
@@ -28,6 +28,8 @@ pnpm add react-simplikit
 
 ## 快速开始
 
+使用 `useDebounce`，在用户停止输入 300 ms 后调用搜索函数。此示例中的 `searchAPI` 是由你的应用提供的搜索函数。
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -62,6 +64,16 @@ function SearchInput() {
 - **工具函数** — `buildContext`、`mergeProps`、`mergeRefs`，以及 `isIOS`、`getKeyboardHeight` 这类移动端 Web 辅助函数
 
 带一句话说明的完整列表见[参考页面](https://react-simplikit.slash.page/zh-Hans/reference.html)。
+
+## AI 集成
+
+使用随附的 agent skill，帮助 AI 编程助手查找现有的 Hook、组件和工具函数，并确认 import 和 SSR 规则。
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+设置方法请参阅 [AI 集成指南（英文）](https://react-simplikit.slash.page/ai-integration.html)。Agent 也可以通过 [llms.txt](https://react-simplikit.slash.page/llms.txt) 查找 API 文档。
 
 ## 文档
 

--- a/packages/react-simplikit/README.md
+++ b/packages/react-simplikit/README.md
@@ -28,6 +28,8 @@ pnpm add react-simplikit
 
 ## Quick Start
 
+Use `useDebounce` to call your search function after the user stops typing for 300 ms. In this example, `searchAPI` is the search function provided by your application.
+
 ```tsx
 import { useState } from 'react';
 import { useDebounce } from 'react-simplikit';
@@ -62,6 +64,16 @@ The debounced function exposes `.cancel()`, and pending calls are cancelled auto
 - **Utils** — `buildContext`, `mergeProps`, `mergeRefs`, and mobile web helpers such as `isIOS` and `getKeyboardHeight`
 
 The full list with a one-line description each is on the [reference page](https://react-simplikit.slash.page/reference.html).
+
+## AI Integration
+
+Help your AI coding assistant find existing hooks, components and utilities, and check import and SSR rules with the included agent skill.
+
+```bash
+npx skills add toss/react-simplikit --skill react-simplikit
+```
+
+See the [AI Integration guide](https://react-simplikit.slash.page/ai-integration.html) for setup details. Agents can also use [llms.txt](https://react-simplikit.slash.page/llms.txt) to find API documentation.
 
 ## Documentation
 

--- a/packages/react-simplikit/README.md
+++ b/packages/react-simplikit/README.md
@@ -77,6 +77,8 @@ See the [AI Integration guide](https://react-simplikit.slash.page/ai-integration
 
 ## Documentation
 
+Choose a hook by the problem you need to solve in [Common use cases](https://react-simplikit.slash.page/use-cases.html).
+
 Visit [react-simplikit.slash.page](https://react-simplikit.slash.page) for full documentation.
 
 ## Contributing

--- a/packages/react-simplikit/src/hooks/useDebounce/ko/useDebounce.md
+++ b/packages/react-simplikit/src/hooks/useDebounce/ko/useDebounce.md
@@ -2,6 +2,8 @@
 
 `useDebounce`는 제공된 콜백 함수의 디바운스 버전을 반환하는 리액트 훅이에요. 함수 실행을 지연시키고 여러 호출을 하나로 그룹화하여 이벤트 처리를 최적화하는 데 도움을 줘요.
 
+기본 옵션에서는 추가 호출 없이 `wait` 밀리초가 지나면 마지막 호출을 실행해요. 언마운트되거나 디바운스 인스턴스가 바뀌면 대기 중인 호출을 취소해요. `.cancel()`은 대기 중인 콜백만 취소하고 이미 시작한 네트워크 요청은 취소하지 않아요. 예제는 전달된 검색어를 로컬에 표시해요. 서버를 연결할 때는 `setSubmittedQuery`를 애플리케이션의 검색 콜백으로 바꾸세요.
+
 ## 인터페이스
 
 ```ts
@@ -63,23 +65,31 @@ function useDebounce<F extends (...args: any[]) => unknown>(
 ## 예시
 
 ```tsx
-function SearchInput() {
-  const [query, setQuery] = useState('');
+import { useState } from 'react';
+import { useDebounce } from 'react-simplikit';
 
-  const debouncedSearch = useDebounce((value: string) => {
-    // 실제 API 호출
-    searchAPI(value);
-  }, 300);
+export function SearchInput() {
+  const [query, setQuery] = useState('');
+  const [submittedQuery, setSubmittedQuery] = useState('');
+  const debouncedSearch = useDebounce(setSubmittedQuery, 300);
 
   return (
-    <input
-      value={query}
-      onChange={e => {
-        setQuery(e.target.value);
-        debouncedSearch(e.target.value);
-      }}
-      placeholder="검색어를 입력하세요"
-    />
+    <section>
+      <label>
+        Search
+        <input
+          value={query}
+          onChange={event => {
+            setQuery(event.target.value);
+            debouncedSearch(event.target.value);
+          }}
+        />
+      </label>
+      <output aria-live="polite">{submittedQuery}</output>
+      <button type="button" onClick={() => debouncedSearch.cancel()}>
+        Cancel pending update
+      </button>
+    </section>
   );
 }
 ```

--- a/packages/react-simplikit/src/hooks/useDebounce/useDebounce.md
+++ b/packages/react-simplikit/src/hooks/useDebounce/useDebounce.md
@@ -2,6 +2,8 @@
 
 `useDebounce` is a React hook that returns a debounced version of the provided callback function. It helps optimize event handling by delaying function execution and grouping multiple calls into one.
 
+With the default options, the last call runs after `wait` milliseconds without another call. Pending calls are cancelled on unmount or when the debounce instance changes. Calling `.cancel()` only cancels a pending callback, not an already-started network request. The example displays the submitted query locally; replace `setSubmittedQuery` with your application's search callback when connecting a server.
+
 ## Interface
 
 ```ts
@@ -63,23 +65,31 @@ function useDebounce<F extends (...args: any[]) => unknown>(
 ## Example
 
 ```tsx
-function SearchInput() {
-  const [query, setQuery] = useState('');
+import { useState } from 'react';
+import { useDebounce } from 'react-simplikit';
 
-  const debouncedSearch = useDebounce((value: string) => {
-    // Actual API call
-    searchAPI(value);
-  }, 300);
+export function SearchInput() {
+  const [query, setQuery] = useState('');
+  const [submittedQuery, setSubmittedQuery] = useState('');
+  const debouncedSearch = useDebounce(setSubmittedQuery, 300);
 
   return (
-    <input
-      value={query}
-      onChange={e => {
-        setQuery(e.target.value);
-        debouncedSearch(e.target.value);
-      }}
-      placeholder="Enter search term"
-    />
+    <section>
+      <label>
+        Search
+        <input
+          value={query}
+          onChange={event => {
+            setQuery(event.target.value);
+            debouncedSearch(event.target.value);
+          }}
+        />
+      </label>
+      <output aria-live="polite">{submittedQuery}</output>
+      <button type="button" onClick={() => debouncedSearch.cancel()}>
+        Cancel pending update
+      </button>
+    </section>
   );
 }
 ```

--- a/packages/react-simplikit/src/hooks/useDebounce/useDebounce.ts
+++ b/packages/react-simplikit/src/hooks/useDebounce/useDebounce.ts
@@ -16,6 +16,12 @@ type DebounceOptions = {
  * `useDebounce` is a React hook that returns a debounced version of the provided callback function.
  * It helps optimize event handling by delaying function execution and grouping multiple calls into one.
  *
+ * With the default options, the last call runs after `wait` milliseconds without another call.
+ * Pending calls are cancelled on unmount or when the debounce instance changes.
+ * Calling `.cancel()` only cancels a pending callback, not an already-started network request.
+ * The example displays the submitted query locally; replace `setSubmittedQuery` with your
+ * application's search callback when connecting a server.
+ *
  * @template {(...args: any[]) => unknown} F - The type of the callback function.
  * @param {F} callback - The function to debounce.
  * @param {number} wait - The number of milliseconds to delay the function execution.
@@ -27,23 +33,31 @@ type DebounceOptions = {
  *   It also includes a `cancel` method to cancel any pending debounced execution.
  *
  * @example
- * function SearchInput() {
- *   const [query, setQuery] = useState('');
+ * import { useState } from 'react';
+ * import { useDebounce } from 'react-simplikit';
  *
- *   const debouncedSearch = useDebounce((value: string) => {
- *     // Actual API call
- *     searchAPI(value);
- *   }, 300);
+ * export function SearchInput() {
+ *   const [query, setQuery] = useState('');
+ *   const [submittedQuery, setSubmittedQuery] = useState('');
+ *   const debouncedSearch = useDebounce(setSubmittedQuery, 300);
  *
  *   return (
- *     <input
- *       value={query}
- *       onChange={e => {
- *         setQuery(e.target.value);
- *         debouncedSearch(e.target.value);
- *       }}
- *       placeholder="Enter search term"
- *     />
+ *     <section>
+ *       <label>
+ *         Search
+ *         <input
+ *           value={query}
+ *           onChange={event => {
+ *             setQuery(event.target.value);
+ *             debouncedSearch(event.target.value);
+ *           }}
+ *         />
+ *       </label>
+ *       <output aria-live="polite">{submittedQuery}</output>
+ *       <button type="button" onClick={() => debouncedSearch.cancel()}>
+ *         Cancel pending update
+ *       </button>
+ *     </section>
  *   );
  * }
  */

--- a/packages/react-simplikit/src/hooks/useDebouncedValue/ko/useDebouncedValue.md
+++ b/packages/react-simplikit/src/hooks/useDebouncedValue/ko/useDebouncedValue.md
@@ -2,6 +2,8 @@
 
 `useDebouncedValue`는 전달받은 값의 디바운스된 사본을 반환하는 리액트 훅이에요. 상태는 호출자가 그대로 소유하고, 훅은 반환값이 그 상태를 얼마나 늦게 따라갈지만 조절해요. 반환값은 마지막 변경 뒤 `wait` 밀리초가 지나면 갱신되므로, 빠르게 바뀌는 상태에서 검색어나 검증 대상을 파생할 때 유용해요.
 
+컴포넌트가 언마운트되면 대기 중인 갱신을 취소해요. 예제는 별도의 검색 서비스나 추가 컴포넌트 없이 지연된 검색어를 표시해요.
+
 첫 렌더와 서버 렌더에서는 값을 그대로 돌려줘요. 마운트 시점에는 갱신을 예약하지 않으므로 `leading: true`이면 마운트 뒤 첫 변경이 즉시 반영돼요. `leading`과 `trailing`이 모두 `false`이면 반환값은 갱신되지 않아요.
 
 값은 참조로 비교해요. 렌더마다 새 객체나 배열을 전달하면 반환값이 `wait` 밀리초마다 계속 갱신되니, `usePreservedReference` 같은 방법으로 참조를 먼저 안정화하세요.
@@ -76,8 +78,11 @@ function SearchInput() {
 
   return (
     <>
-      <input value={query} onChange={e => setQuery(e.target.value)} />
-      <SearchResults query={debouncedQuery} />
+      <label>
+        Search
+        <input value={query} onChange={e => setQuery(e.target.value)} />
+      </label>
+      <output aria-live="polite">{debouncedQuery}</output>
     </>
   );
 }

--- a/packages/react-simplikit/src/hooks/useDebouncedValue/useDebouncedValue.md
+++ b/packages/react-simplikit/src/hooks/useDebouncedValue/useDebouncedValue.md
@@ -2,6 +2,8 @@
 
 `useDebouncedValue` is a React hook that returns a debounced copy of the given value. The caller keeps owning the state; the hook only delays how quickly the returned value follows it. The returned value updates `wait` milliseconds after the last change, which is useful for deriving a search query or a validation input from fast-changing state.
 
+Pending updates are cancelled when the component unmounts. The example displays the delayed query without requiring a search service or an additional component.
+
 On the first render and on the server the value is returned as is. A change is never scheduled on mount, so with `leading: true` the first change after mount is applied immediately. If both `leading` and `trailing` are `false`, the returned value never updates.
 
 The value is compared by reference. Passing a new object or array on every render keeps the returned value updating every `wait` milliseconds; stabilize the reference first, for example with `usePreservedReference`.
@@ -72,8 +74,11 @@ function SearchInput() {
 
   return (
     <>
-      <input value={query} onChange={e => setQuery(e.target.value)} />
-      <SearchResults query={debouncedQuery} />
+      <label>
+        Search
+        <input value={query} onChange={e => setQuery(e.target.value)} />
+      </label>
+      <output aria-live="polite">{debouncedQuery}</output>
     </>
   );
 }

--- a/packages/react-simplikit/src/hooks/useDebouncedValue/useDebouncedValue.ts
+++ b/packages/react-simplikit/src/hooks/useDebouncedValue/useDebouncedValue.ts
@@ -14,6 +14,9 @@ type DebounceOptions = {
  * The returned value updates `wait` milliseconds after the last change, which is useful for
  * deriving a search query or a validation input from fast-changing state.
  *
+ * Pending updates are cancelled when the component unmounts. The example displays the
+ * delayed query without requiring a search service or an additional component.
+ *
  * On the first render and on the server the value is returned as is. A change is never scheduled
  * on mount, so with `leading: true` the first change after mount is applied immediately.
  * If both `leading` and `trailing` are `false`, the returned value never updates.
@@ -41,8 +44,11 @@ type DebounceOptions = {
  *
  *   return (
  *     <>
- *       <input value={query} onChange={e => setQuery(e.target.value)} />
- *       <SearchResults query={debouncedQuery} />
+ *       <label>
+ *         Search
+ *         <input value={query} onChange={e => setQuery(e.target.value)} />
+ *       </label>
+ *       <output aria-live="polite">{debouncedQuery}</output>
  *     </>
  *   );
  * }


### PR DESCRIPTION
# Overview

Closes #491 

Help users find the right API for common React problems, run the examples, and navigate to reference docs and AI integration resources.

- Improve example descriptions and AI integration links in root and package READMEs across all five supported languages.
- Add a common-use-cases guide with an API selection table and runnable toggle and search examples. Connect it to the introduction, installation guide, reference index, and sidebar.
- Make the `useDebounce` and `useDebouncedValue` examples self-contained, clarify SSR initial values and cancellation behavior, and regenerate API docs and bundled skill references from JSDoc.
- Add an agent-access verification guide and Japanese, Simplified Chinese, and Spanish AI integration translations. Independently verify that an agent can find imports, defaults, and cancellation behavior in the local skill catalog and bundled references.
- Add page-specific descriptions, canonical URLs, and Open Graph/Twitter metadata. Preserve explicit descriptions, point untranslated fallback pages to their English originals, and exclude those fallbacks from sitemap entries and language alternates. Reuse VitePress without adding dependencies.
- Add 14 tests that execute examples directly from Markdown, plus checks for guide links, translations, public API names, generated Markdown, SEO metadata, and sitemap consistency.

Existing public URLs and heading anchors are preserved. Library runtime implementations are unchanged.

Validation passed: `yarn test:docs` (39 tests and the multilingual build), `yarn test:skill`, `yarn typecheck`, `yarn lint`, scoped Prettier checks, and independent translation and code reviews. Four documented examples were also type-checked. Browser checks confirmed guide-to-API navigation and metadata updates during client-side navigation. Validation covers local sources and builds; actual agent installation and the new routes on the deployed site were not tested.

## Checklist

- [x] Did you write the test code?
- [ ] Have you run `yarn run fix` to format and lint the code and docs? — Ran Prettier on changed files and `yarn lint` instead of a repository-wide autofix.
- [ ] Have you run `yarn run test:coverage` to make sure there is no uncovered line? — Ran documentation tests locally because library runtime code is unchanged.
- [x] Did you write the JSDoc?
